### PR TITLE
유저 정보 수정 기능 구현

### DIFF
--- a/Budi/Budi.xcodeproj/project.pbxproj
+++ b/Budi/Budi.xcodeproj/project.pbxproj
@@ -1650,13 +1650,13 @@
 				CODE_SIGN_ENTITLEMENTS = Budi/Budi.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = V37X2D6JM3;
+				DEVELOPMENT_TEAM = ZMXTCSPNUZ;
 				INFOPLIST_FILE = Budi/Resource/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = kr.dochoi.Budi;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.dochoi.Budi2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -1673,13 +1673,13 @@
 				CODE_SIGN_ENTITLEMENTS = Budi/Budi.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = V37X2D6JM3;
+				DEVELOPMENT_TEAM = ZMXTCSPNUZ;
 				INFOPLIST_FILE = Budi/Resource/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = kr.dochoi.Budi;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.dochoi.Budi2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;

--- a/Budi/Budi.xcodeproj/project.pbxproj
+++ b/Budi/Budi.xcodeproj/project.pbxproj
@@ -176,6 +176,17 @@
 		A8CE1193278B1F82008AFEBC /* MyBudiProjectDetailCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CE1190278B1F82008AFEBC /* MyBudiProjectDetailCollectionViewCell.swift */; };
 		A8CE1194278B1F82008AFEBC /* MyBudiProjectDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CE1191278B1F82008AFEBC /* MyBudiProjectDetailViewController.swift */; };
 		A8CE1196278B1F91008AFEBC /* MyBudiContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CE1195278B1F90008AFEBC /* MyBudiContentViewController.swift */; };
+		A8E03CCF278C68A40074DE4B /* NormalTextFieldTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E03CCD278C68A40074DE4B /* NormalTextFieldTableViewCell.swift */; };
+		A8E03CD0278C68A40074DE4B /* NormalTextFieldTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = A8E03CCE278C68A40074DE4B /* NormalTextFieldTableViewCell.xib */; };
+		A8E03CD3278C693C0074DE4B /* LocationReplaceTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E03CD1278C693C0074DE4B /* LocationReplaceTableViewCell.swift */; };
+		A8E03CD4278C693C0074DE4B /* LocationReplaceTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = A8E03CD2278C693C0074DE4B /* LocationReplaceTableViewCell.xib */; };
+		A8E03CD7278C6B030074DE4B /* PositionTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E03CD5278C6B030074DE4B /* PositionTableViewCell.swift */; };
+		A8E03CD8278C6B030074DE4B /* PositionTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = A8E03CD6278C6B030074DE4B /* PositionTableViewCell.xib */; };
+		A8E03CDB278C79870074DE4B /* ProjectTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E03CD9278C79870074DE4B /* ProjectTableViewCell.swift */; };
+		A8E03CDC278C79870074DE4B /* ProjectTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = A8E03CDA278C79870074DE4B /* ProjectTableViewCell.xib */; };
+		A8E03CDE278C7C3E0074DE4B /* MyBudiEditHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E03CDD278C7C3E0074DE4B /* MyBudiEditHeaderView.swift */; };
+		A8E03CE0278C7C680074DE4B /* MyBudiEditHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = A8E03CDF278C7C680074DE4B /* MyBudiEditHeaderView.xib */; };
+		A8E03CE2278C98E40074DE4B /* PositionSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E03CE1278C98E40074DE4B /* PositionSwitch.swift */; };
 		B92D54F9274C02EB00D0E851 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = B92D54F8274C02EB00D0E851 /* .swiftlint.yml */; };
 		B92D5505274C03AB00D0E851 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = B92D5504274C03AA00D0E851 /* Post.swift */; };
 		B94D2D9A277DE9E700DD7FDD /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = B94D2D99277DE9E700DD7FDD /* GoogleService-Info.plist */; };
@@ -404,6 +415,17 @@
 		A8CE1190278B1F82008AFEBC /* MyBudiProjectDetailCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyBudiProjectDetailCollectionViewCell.swift; sourceTree = "<group>"; };
 		A8CE1191278B1F82008AFEBC /* MyBudiProjectDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyBudiProjectDetailViewController.swift; sourceTree = "<group>"; };
 		A8CE1195278B1F90008AFEBC /* MyBudiContentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyBudiContentViewController.swift; sourceTree = "<group>"; };
+		A8E03CCD278C68A40074DE4B /* NormalTextFieldTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalTextFieldTableViewCell.swift; sourceTree = "<group>"; };
+		A8E03CCE278C68A40074DE4B /* NormalTextFieldTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NormalTextFieldTableViewCell.xib; sourceTree = "<group>"; };
+		A8E03CD1278C693C0074DE4B /* LocationReplaceTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationReplaceTableViewCell.swift; sourceTree = "<group>"; };
+		A8E03CD2278C693C0074DE4B /* LocationReplaceTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LocationReplaceTableViewCell.xib; sourceTree = "<group>"; };
+		A8E03CD5278C6B030074DE4B /* PositionTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionTableViewCell.swift; sourceTree = "<group>"; };
+		A8E03CD6278C6B030074DE4B /* PositionTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PositionTableViewCell.xib; sourceTree = "<group>"; };
+		A8E03CD9278C79870074DE4B /* ProjectTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectTableViewCell.swift; sourceTree = "<group>"; };
+		A8E03CDA278C79870074DE4B /* ProjectTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProjectTableViewCell.xib; sourceTree = "<group>"; };
+		A8E03CDD278C7C3E0074DE4B /* MyBudiEditHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyBudiEditHeaderView.swift; sourceTree = "<group>"; };
+		A8E03CDF278C7C680074DE4B /* MyBudiEditHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MyBudiEditHeaderView.xib; sourceTree = "<group>"; };
+		A8E03CE1278C98E40074DE4B /* PositionSwitch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionSwitch.swift; sourceTree = "<group>"; };
 		B92D54F8274C02EB00D0E851 /* .swiftlint.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		B92D54FE274C037E00D0E851 /* String+date.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+date.swift"; sourceTree = "<group>"; };
 		B92D5501274C039C00D0E851 /* HomeContentViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeContentViewModel.swift; sourceTree = "<group>"; };
@@ -594,6 +616,16 @@
 		5E9150A42772355B000578D4 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
+				A8E03CCD278C68A40074DE4B /* NormalTextFieldTableViewCell.swift */,
+				A8E03CCE278C68A40074DE4B /* NormalTextFieldTableViewCell.xib */,
+				A8E03CD1278C693C0074DE4B /* LocationReplaceTableViewCell.swift */,
+				A8E03CD2278C693C0074DE4B /* LocationReplaceTableViewCell.xib */,
+				A8E03CD5278C6B030074DE4B /* PositionTableViewCell.swift */,
+				A8E03CD6278C6B030074DE4B /* PositionTableViewCell.xib */,
+				A8E03CD9278C79870074DE4B /* ProjectTableViewCell.swift */,
+				A8E03CDA278C79870074DE4B /* ProjectTableViewCell.xib */,
+				A8E03CDD278C7C3E0074DE4B /* MyBudiEditHeaderView.swift */,
+				A8E03CDF278C7C680074DE4B /* MyBudiEditHeaderView.xib */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -927,6 +959,7 @@
 				A8CE117D278AC682008AFEBC /* MyLikePost.swift */,
 				A8CE117F278ACD88008AFEBC /* MyBudiProject.swift */,
 				5EE7FB452787E11200D9C39F /* ErrorMessage.swift */,
+				A8E03CE1278C98E40074DE4B /* PositionSwitch.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1172,6 +1205,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A8E03CD0278C68A40074DE4B /* NormalTextFieldTableViewCell.xib in Resources */,
+				A8E03CDC278C79870074DE4B /* ProjectTableViewCell.xib in Resources */,
 				B92D54F9274C02EB00D0E851 /* .swiftlint.yml in Resources */,
 				5E43FB3E278A95EF0073574F /* ChattingProjectRequestCell.xib in Resources */,
 				5E820B8B2769F04A004A03E9 /* ProjectMembersBottomDetailCell.xib in Resources */,
@@ -1181,6 +1216,7 @@
 				5EB430362758953000283239 /* HomeWritingOnlineCell.xib in Resources */,
 				5EB4302A2758950400283239 /* HomeWritingNameCell.xib in Resources */,
 				5EFB0A5B27341C1100F39A4D /* ChattingTimeCell.xib in Resources */,
+				A8E03CE0278C7C680074DE4B /* MyBudiEditHeaderView.xib in Resources */,
 				5EA453A12731778000943C94 /* HomeDetailMainCell.xib in Resources */,
 				B94D2D9A277DE9E700DD7FDD /* GoogleService-Info.plist in Resources */,
 				5EB430322758952500283239 /* HomeWritingDurationCell.xib in Resources */,
@@ -1212,6 +1248,7 @@
 				5E91509B27722213000578D4 /* MyBudiProjectCell.xib in Resources */,
 				5E2554362732770B00033723 /* HomeDetailPersonCell.xib in Resources */,
 				5E820B902769F963004A03E9 /* DatePickerBottomViewController.xib in Resources */,
+				A8E03CD8278C6B030074DE4B /* PositionTableViewCell.xib in Resources */,
 				5EFB0A462733E36800F39A4D /* TeamSearchCell.xib in Resources */,
 				5EC2FEFA275E191F00FF5BB0 /* HomeDetailStatusUnitCell.xib in Resources */,
 				5EA453912731774100943C94 /* HomeDetailMemberCell.xib in Resources */,
@@ -1229,6 +1266,7 @@
 				5E503E7827898D1400F13256 /* ProjectMembersBottomViewController.xib in Resources */,
 				5E7CF4C92770B79E007315F1 /* ProjectMembersBottomPositionCell.xib in Resources */,
 				5E5517AA2768BCC300DC605E /* HomeWritingPartBottomCell.xib in Resources */,
+				A8E03CD4278C693C0074DE4B /* LocationReplaceTableViewCell.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1298,6 +1336,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A8E03CDE278C7C3E0074DE4B /* MyBudiEditHeaderView.swift in Sources */,
 				B9684168277853F3002F5D3D /* alertView.swift in Sources */,
 				B9684167277853EF002F5D3D /* HomeContentViewModel.swift in Sources */,
 				B9684166277853E7002F5D3D /* HomeContainerViewController.swift in Sources */,
@@ -1312,6 +1351,8 @@
 				B968415F277853BC002F5D3D /* ProjectHistory.swift in Sources */,
 				5E9150A62772356A000578D4 /* MyBudiEditCellType.swift in Sources */,
 				5E88636E2767450A0022397A /* HomeWritingCellType.swift in Sources */,
+				A8E03CD3278C693C0074DE4B /* LocationReplaceTableViewCell.swift in Sources */,
+				A8E03CDB278C79870074DE4B /* ProjectTableViewCell.swift in Sources */,
 				5E8863822767AE190022397A /* HomeWritingImageBottomCell.swift in Sources */,
 				5EF986CA2786E58600874A40 /* Leader.swift in Sources */,
 				A8CE1196278B1F91008AFEBC /* MyBudiContentViewController.swift in Sources */,
@@ -1333,6 +1374,7 @@
 				B97A862D2786D6DB0016CF23 /* TeamSearchProfileCell.swift in Sources */,
 				A8CD936127384C4900299AB4 /* SearchTableViewCell.swift in Sources */,
 				A85C920B276A35270097E444 /* PortfolioViewController.swift in Sources */,
+				A8E03CCF278C68A40074DE4B /* NormalTextFieldTableViewCell.swift in Sources */,
 				B94D2D9C277DFE2300DD7FDD /* TeamSearchViewModel.swift in Sources */,
 				B92D5505274C03AB00D0E851 /* Post.swift in Sources */,
 				5EB4302D2758951600283239 /* HomeWritingPartCell.swift in Sources */,
@@ -1376,6 +1418,7 @@
 				B9BF787427004094000BE0EF /* AppDelegate.swift in Sources */,
 				A81D105F2764828A0022D610 /* HistoryWriteViewController.swift in Sources */,
 				5E503E7727898D1400F13256 /* ProjectMembersBottomViewController.swift in Sources */,
+				A8E03CE2278C98E40074DE4B /* PositionSwitch.swift in Sources */,
 				B96F33BD27859C6D000A0B42 /* UIView+gesturePublisher.swift in Sources */,
 				5EFB0A522734016600F39A4D /* MyChattingMessageCell.swift in Sources */,
 				B968416B277862ED002F5D3D /* TeamSearchDetailCell.swift in Sources */,
@@ -1451,6 +1494,7 @@
 				5EBD9D5D276DB57B00615319 /* HomeDetailViewModel.swift in Sources */,
 				5E91508D27721D8B000578D4 /* MyBudiMainViewController.swift in Sources */,
 				5E58E6B1276B588C00ABBF1C /* AppliesRequest.swift in Sources */,
+				A8E03CD7278C6B030074DE4B /* PositionTableViewCell.swift in Sources */,
 				5EB430452758959600283239 /* HomeWritingDescriptionCell.swift in Sources */,
 				A81D1061276482950022D610 /* DefaultTableViewCell.swift in Sources */,
 				5E91509627722206000578D4 /* MyBudiLevelCell.swift in Sources */,

--- a/Budi/Budi/Resource/Assets.xcassets/BackgoundImage/bg_ invitation_message.imageset/Contents.json
+++ b/Budi/Budi/Resource/Assets.xcassets/BackgoundImage/bg_ invitation_message.imageset/Contents.json
@@ -1,17 +1,17 @@
 {
   "images" : [
     {
-      "filename" : "그림 04.png",
+      "filename" : "그림 04.png",
       "idiom" : "universal",
       "scale" : "1x"
     },
     {
-      "filename" : "그림 04@2x.png",
+      "filename" : "그림 04@2x.png",
       "idiom" : "universal",
       "scale" : "2x"
     },
     {
-      "filename" : "그림 04@3x.png",
+      "filename" : "그림 04@3x.png",
       "idiom" : "universal",
       "scale" : "3x"
     }

--- a/Budi/Budi/Resource/Assets.xcassets/BackgoundImage/bg_error.imageset/Contents.json
+++ b/Budi/Budi/Resource/Assets.xcassets/BackgoundImage/bg_error.imageset/Contents.json
@@ -1,17 +1,17 @@
 {
   "images" : [
     {
-      "filename" : "그림 05.png",
+      "filename" : "그림 05.png",
       "idiom" : "universal",
       "scale" : "1x"
     },
     {
-      "filename" : "그림 05@2x.png",
+      "filename" : "그림 05@2x.png",
       "idiom" : "universal",
       "scale" : "2x"
     },
     {
-      "filename" : "그림 05@3x.png",
+      "filename" : "그림 05@3x.png",
       "idiom" : "universal",
       "scale" : "3x"
     }

--- a/Budi/Budi/Resource/Assets.xcassets/BackgoundImage/bg_error_isAlreadyApplied.imageset/Contents.json
+++ b/Budi/Budi/Resource/Assets.xcassets/BackgoundImage/bg_error_isAlreadyApplied.imageset/Contents.json
@@ -1,17 +1,17 @@
 {
   "images" : [
     {
-      "filename" : "그림 03.png",
+      "filename" : "그림 03.png",
       "idiom" : "universal",
       "scale" : "1x"
     },
     {
-      "filename" : "그림 03@2x.png",
+      "filename" : "그림 03@2x.png",
       "idiom" : "universal",
       "scale" : "2x"
     },
     {
-      "filename" : "그림 03@3x.png",
+      "filename" : "그림 03@3x.png",
       "idiom" : "universal",
       "scale" : "3x"
     }

--- a/Budi/Budi/Resource/Info.plist
+++ b/Budi/Budi/Resource/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>앨범 사용 권한을 허용합니다.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>카메라 사용 권한을 허용합니다.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/Budi/Budi/Source/Chatting/ChatManager.swift
+++ b/Budi/Budi/Source/Chatting/ChatManager.swift
@@ -59,8 +59,6 @@ final class ChatManager {
 //            let messages = documents.compactMap { (document) -> ChatMessage? in
 //                return try? document.data(as: ChatMessage.self)
 //            }
-            
-            print("messages: \(documents)")
         }
         
         return messages

--- a/Budi/Budi/Source/Home/HomeCoordinator.swift
+++ b/Budi/Budi/Source/Home/HomeCoordinator.swift
@@ -67,7 +67,7 @@ extension HomeCoordinator {
     }
     
     func showProjectMembersBottomViewController(_ vc: UIViewController, _ viewModel: HomeWritingViewModel) {
-        let viewController: ProjectMembersBottomViewController = ProjectMembersBottomViewController(nibName: ProjectMembersBottomViewController.identifier, bundle: nil, developerPositions: viewModel.state.developerPositions.value, designerPositions: viewModel.state.designerPositions.value, productManagerPositions: viewModel.state.productManagerPositions.value)
+        let viewController: ProjectMembersBottomViewController = ProjectMembersBottomViewController(nibName: ProjectMembersBottomViewController.identifier, bundle: nil, developerPositions: viewModel.state.developerPositions.value, designerPositions: viewModel.state.designerPositions.value, productManagerPositions: viewModel.state.productManagerPositions.value, viewSwitch: .writing)
         viewController.delegate = vc as? ProjectMembersBottomViewControllerDelegate
         viewController.modalPresentationStyle = .overCurrentContext
         vc.present(viewController, animated: false, completion: nil)

--- a/Budi/Budi/Source/Home/HomeDetail/HomeDetailCells/HomeDetailViewController.swift
+++ b/Budi/Budi/Source/Home/HomeDetail/HomeDetailCells/HomeDetailViewController.swift
@@ -72,16 +72,12 @@ private extension HomeDetailViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self = self, let isAlreadyApplied = self.viewModel.state.post.value?.isAlreadyApplied else { return }
-                
                 if UserDefaults.standard.string(forKey: "accessToken") == "" {
                     let storyboard = UIStoryboard(name: "Main", bundle: nil)
                     let loginSelectViewController = storyboard.instantiateViewController(identifier: "LoginSelectViewController")
                     let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
                     sceneDelegate?.moveLoginController(loginSelectViewController, animated: true)
                 } else {
-
-                    guard let isAlreadyApplied = self.viewModel.state.post.value?.isAlreadyApplied else { return }
-
                     if isAlreadyApplied {
                         let errorAlertVC = ErrorAlertViewController(ErrorMessage.isAlreadyApplied)
                         errorAlertVC.modalPresentationStyle = .overCurrentContext
@@ -127,8 +123,6 @@ private extension HomeDetailViewController {
 
 private extension HomeDetailViewController {
     func configureNavigationBar() {
-//        let shareButton = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(shareButtonTapped))
-//        navigationItem.rightBarButtonItem = shareButton
         navigationController?.navigationBar.tintColor = .systemGray
     }
 

--- a/Budi/Budi/Source/Home/HomeWriting/BottomSheets/ProjectMembersBottomView/ProjectMembersBottomViewController.swift
+++ b/Budi/Budi/Source/Home/HomeWriting/BottomSheets/ProjectMembersBottomView/ProjectMembersBottomViewController.swift
@@ -29,16 +29,17 @@ final class ProjectMembersBottomViewController: UIViewController {
     private let developerPositions: [String]
     private let designerPositions: [String]
     private let productManagerPositions: [String]
-    
+    private var positionSwitch: PositionSwitch
     private var selectedPosition: Position?
     private var recruitingPositions: [RecruitingPosition] = []
     
     weak var delegate: ProjectMembersBottomViewControllerDelegate?
 
-    init(nibName: String?, bundle: Bundle?, developerPositions: [String], designerPositions: [String], productManagerPositions: [String]) {
+    init(nibName: String?, bundle: Bundle?, developerPositions: [String], designerPositions: [String], productManagerPositions: [String], viewSwitch: PositionSwitch) {
         self.developerPositions = developerPositions
         self.designerPositions = designerPositions
         self.productManagerPositions = productManagerPositions
+        self.positionSwitch = viewSwitch
         super.init(nibName: nibName, bundle: bundle)
     }
     
@@ -240,7 +241,13 @@ extension ProjectMembersBottomViewController: UICollectionViewDataSource, UIColl
             self.configureCompleteButton(!recruitingPositions.isEmpty)
 
             let count = recruitingPositions.count < 4 ? recruitingPositions.count : 3
-            self.showBottomView(constant: 350+CGFloat(48*count)+40)
+
+            switch positionSwitch {
+            case .writing:
+                self.showBottomView(constant: 350+CGFloat(48*count)+40)
+            case .myBudi:
+                break
+            }
             
             self.detailCollectionView.reloadData()
             self.memberCollectionView.reloadData()

--- a/Budi/Budi/Source/Home/HomeWriting/BottomSheets/ProjectMembersBottomView/ProjectMembersBottomViewController.swift
+++ b/Budi/Budi/Source/Home/HomeWriting/BottomSheets/ProjectMembersBottomView/ProjectMembersBottomViewController.swift
@@ -9,7 +9,13 @@ import UIKit
 import Combine
 
 protocol ProjectMembersBottomViewControllerDelegate: AnyObject {
-    func getRecruitingPositions(_ recruitingPositions: [RecruitingPosition])
+    func getRecruitingPositions(_ recruitingPositions: [RecruitingPosition], _ selectPosition: Int)
+}
+
+extension ProjectMembersBottomViewControllerDelegate {
+    func getRecruitingPositions(_ recruitingPositions: [RecruitingPosition], _ selectPosition: Int = 0) {
+        getRecruitingPositions(recruitingPositions, selectPosition)
+    }
 }
 
 final class ProjectMembersBottomViewController: UIViewController {
@@ -32,7 +38,7 @@ final class ProjectMembersBottomViewController: UIViewController {
     private var positionSwitch: PositionSwitch
     private var selectedPosition: Position?
     private var recruitingPositions: [RecruitingPosition] = []
-    
+    private var selectPosition: Int = 0
     weak var delegate: ProjectMembersBottomViewControllerDelegate?
 
     init(nibName: String?, bundle: Bundle?, developerPositions: [String], designerPositions: [String], productManagerPositions: [String], viewSwitch: PositionSwitch) {
@@ -76,7 +82,12 @@ private extension ProjectMembersBottomViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self = self else { return }
-                self.delegate?.getRecruitingPositions(self.recruitingPositions)
+                switch self.positionSwitch {
+                case .myBudi:
+                    self.delegate?.getRecruitingPositions(self.recruitingPositions, self.selectPosition)
+                case .writing:
+                    self.delegate?.getRecruitingPositions(self.recruitingPositions)
+                }
                 self.hideBottomView()
             }.store(in: &cancellables)
     }
@@ -213,6 +224,7 @@ extension ProjectMembersBottomViewController: UICollectionViewDataSource, UIColl
             if selectedPosition == nil {
                 showBottomView(constant: 350)
             }
+            self.selectPosition = indexPath.row+1
             guard let newSelectedPosition = Position(rawValue: indexPath.row+1),
                     newSelectedPosition != self.selectedPosition else { return }
             self.selectedPosition = newSelectedPosition

--- a/Budi/Budi/Source/Home/HomeWriting/BottomSheets/ProjectMembersBottomView/ProjectMembersBottomViewController.swift
+++ b/Budi/Budi/Source/Home/HomeWriting/BottomSheets/ProjectMembersBottomView/ProjectMembersBottomViewController.swift
@@ -12,12 +12,6 @@ protocol ProjectMembersBottomViewControllerDelegate: AnyObject {
     func getRecruitingPositions(_ recruitingPositions: [RecruitingPosition], _ selectPosition: Int)
 }
 
-extension ProjectMembersBottomViewControllerDelegate {
-    func getRecruitingPositions(_ recruitingPositions: [RecruitingPosition], _ selectPosition: Int = 0) {
-        getRecruitingPositions(recruitingPositions, selectPosition)
-    }
-}
-
 final class ProjectMembersBottomViewController: UIViewController {
 
     @IBOutlet private weak var backgroundView: UIView!
@@ -74,7 +68,7 @@ private extension ProjectMembersBottomViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self = self else { return }
-                self.delegate?.getRecruitingPositions(self.recruitingPositions)
+                self.delegate?.getRecruitingPositions(self.recruitingPositions, 0)
                 self.hideBottomView()
             }.store(in: &cancellables)
         
@@ -86,7 +80,7 @@ private extension ProjectMembersBottomViewController {
                 case .myBudi:
                     self.delegate?.getRecruitingPositions(self.recruitingPositions, self.selectPosition)
                 case .writing:
-                    self.delegate?.getRecruitingPositions(self.recruitingPositions)
+                    self.delegate?.getRecruitingPositions(self.recruitingPositions, 0)
                 }
                 self.hideBottomView()
             }.store(in: &cancellables)

--- a/Budi/Budi/Source/Home/HomeWriting/BottomSheets/ProjectMembersBottomView/ProjectMembersBottomViewController.swift
+++ b/Budi/Budi/Source/Home/HomeWriting/BottomSheets/ProjectMembersBottomView/ProjectMembersBottomViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 import Combine
 
 protocol ProjectMembersBottomViewControllerDelegate: AnyObject {
-    func getRecruitingPositions(_ recruitingPositions: [RecruitingPosition], _ selectPosition: Int)
+    func getRecruitingPositions(_ recruitingPositions: [RecruitingPosition], _ selectPosition: Int?)
 }
 
 final class ProjectMembersBottomViewController: UIViewController {
@@ -68,7 +68,7 @@ private extension ProjectMembersBottomViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self = self else { return }
-                self.delegate?.getRecruitingPositions(self.recruitingPositions, 0)
+                self.delegate?.getRecruitingPositions(self.recruitingPositions, nil)
                 self.hideBottomView()
             }.store(in: &cancellables)
         
@@ -80,7 +80,7 @@ private extension ProjectMembersBottomViewController {
                 case .myBudi:
                     self.delegate?.getRecruitingPositions(self.recruitingPositions, self.selectPosition)
                 case .writing:
-                    self.delegate?.getRecruitingPositions(self.recruitingPositions, 0)
+                    self.delegate?.getRecruitingPositions(self.recruitingPositions, nil)
                 }
                 self.hideBottomView()
             }.store(in: &cancellables)

--- a/Budi/Budi/Source/Home/HomeWriting/BottomSheets/ProjectMembersBottomView/ProjectMembersBottomViewController.xib
+++ b/Budi/Budi/Source/Home/HomeWriting/BottomSheets/ProjectMembersBottomView/ProjectMembersBottomViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>

--- a/Budi/Budi/Source/Home/HomeWriting/HomeWritingViewController.swift
+++ b/Budi/Budi/Source/Home/HomeWriting/HomeWritingViewController.swift
@@ -202,7 +202,7 @@ extension HomeWritingViewController: HomeLocationSearchViewControllerDelegate {
 }
 
 extension HomeWritingViewController: ProjectMembersBottomViewControllerDelegate {
-    func getRecruitingPositions(_ recruitingPositions: [RecruitingPosition]) {
+    func getRecruitingPositions(_ recruitingPositions: [RecruitingPosition], _ selectPosition: Int) {
         viewModel.state.recruitingPositions.value = recruitingPositions
         collectionView.reloadData()
         isValid()

--- a/Budi/Budi/Source/Home/HomeWriting/HomeWritingViewController.swift
+++ b/Budi/Budi/Source/Home/HomeWriting/HomeWritingViewController.swift
@@ -202,7 +202,7 @@ extension HomeWritingViewController: HomeLocationSearchViewControllerDelegate {
 }
 
 extension HomeWritingViewController: ProjectMembersBottomViewControllerDelegate {
-    func getRecruitingPositions(_ recruitingPositions: [RecruitingPosition], _ selectPosition: Int) {
+    func getRecruitingPositions(_ recruitingPositions: [RecruitingPosition], _ selectPosition: Int?) {
         viewModel.state.recruitingPositions.value = recruitingPositions
         collectionView.reloadData()
         isValid()

--- a/Budi/Budi/Source/Login/View/NickNameView.swift
+++ b/Budi/Budi/Source/Login/View/NickNameView.swift
@@ -80,7 +80,6 @@ class NickNameView: UIView {
 
     func checkID(flag: Bool?) {
         if flag == nil {
-            checkTextLabel.text = ""
             return
         }
         guard let flag = flag else { return }
@@ -93,8 +92,13 @@ class NickNameView: UIView {
         }
     }
 
-    func emptyText() {
-        checkTextLabel.text = ""
+    func emptyText(text: String) {
+        if text.count == 0 {
+            checkTextLabel.text = ""
+        } else {
+            checkTextLabel.text = "닉네임은 3글자 이상입니다."
+            checkTextLabel.textColor = UIColor.primary
+        }
     }
 
     private func configureObserver() {

--- a/Budi/Budi/Source/Login/ViewController/HistoryManagement/HistoryManagementViewController.swift
+++ b/Budi/Budi/Source/Login/ViewController/HistoryManagement/HistoryManagementViewController.swift
@@ -10,7 +10,6 @@ import CombineCocoa
 import Combine
 
 
-
 class HistoryManagementViewController: UIViewController {
     weak var coordinator: LoginCoordinator?
     private let viewModel: SignupViewModel
@@ -169,7 +168,7 @@ extension HistoryManagementViewController: UITableViewDelegate, UITableViewDataS
         if data.itemInfo.isInclude {
             if data.portfolioLink.count >= 1 {
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: PortfolioURLTableViewCell.cellId, for: indexPath) as? PortfolioURLTableViewCell else { return UITableViewCell() }
-                cell.configureParsing(url: data.portfolioLink)
+                cell.configureParsing(urlString: data.portfolioLink)
 
                 cell.editButton.tapPublisher
                     .receive(on: DispatchQueue.main)

--- a/Budi/Budi/Source/Login/ViewController/HistoryManagement/HistoryManagementViewController.swift
+++ b/Budi/Budi/Source/Login/ViewController/HistoryManagement/HistoryManagementViewController.swift
@@ -9,6 +9,8 @@ import UIKit
 import CombineCocoa
 import Combine
 
+
+
 class HistoryManagementViewController: UIViewController {
     weak var coordinator: LoginCoordinator?
     private let viewModel: SignupViewModel

--- a/Budi/Budi/Source/Login/ViewController/HistoryManagement/PortfolioViewController.swift
+++ b/Budi/Budi/Source/Login/ViewController/HistoryManagement/PortfolioViewController.swift
@@ -10,7 +10,7 @@ import Combine
 import CombineCocoa
 
 protocol PortfolioViewControllerDelegate: AnyObject {
-    func getPortfolio(_ portfolio: SignupInfoModel)
+    func getPortfolio(_ portfolio: SignupInfoModel?)
 }
 
 class PortfolioViewController: UIViewController {
@@ -67,7 +67,7 @@ class PortfolioViewController: UIViewController {
                 guard let text = text else { return }
                 guard var data = self?.viewModel.state.writedInfoData.value else { return }
                 data.porflioLink = text
-                print(data.porflioLink)
+                print(data)
                 self?.viewModel.state.writedInfoData.send(data)
                 
             }
@@ -78,8 +78,7 @@ class PortfolioViewController: UIViewController {
             .sink { [weak self] _ in
                 guard let self = self else { return }
                 if self.myBudiCoordinator != nil {
-                    let send = self.viewModel.state.writedPortfolioData.value
-                    print("입력받은 텍스트", send)
+                    let send = self.viewModel.state.writedInfoData.value
                     self.delegate?.getPortfolio(send)
                 } else {
                     self.viewModel.action.fetchSignupInfoData.send(())

--- a/Budi/Budi/Source/Login/ViewController/HistoryManagement/PortfolioViewController.swift
+++ b/Budi/Budi/Source/Login/ViewController/HistoryManagement/PortfolioViewController.swift
@@ -10,7 +10,7 @@ import Combine
 import CombineCocoa
 
 protocol PortfolioViewControllerDelegate: AnyObject {
-    func getPortfolio(_ portfolio: SignupInfoModel?)
+    func getPortfolio(_ portfolio: SignupInfoModel?, _ editItem: Item?)
 }
 
 class PortfolioViewController: UIViewController {
@@ -79,9 +79,14 @@ class PortfolioViewController: UIViewController {
                 guard let self = self else { return }
                 if self.myBudiCoordinator != nil {
                     let send = self.viewModel.state.writedInfoData.value
-                    self.delegate?.getPortfolio(send)
+                    if self.viewModel.state.editData.value != nil {
+                        self.delegate?.getPortfolio(send, self.viewModel.state.editData.value)
+                    } else {
+                        self.delegate?.getPortfolio(send, nil)
+                    }
                 } else {
                     self.viewModel.action.fetchSignupInfoData.send(())
+                    self.viewModel.state.editData.send(nil)
                 }
 
                 NotificationCenter.default.post(name: Notification.Name("Dismiss"), object: self)
@@ -109,6 +114,12 @@ class PortfolioViewController: UIViewController {
                 self.saveButton.backgroundColor = data.porflioLink.count >= 1 ? UIColor.primary : UIColor.textDisabled
                 self.saveButton.setTitleColor(UIColor.white, for: .normal)
                 self.saveButton.setTitleColor(UIColor.white, for: .disabled)
+
+                if self.viewModel.state.editData.value != nil {
+
+                    self.saveButton.isEnabled = true
+                    self.saveButton.backgroundColor = UIColor.primary
+                }
             }
             .store(in: &cancellables)
 

--- a/Budi/Budi/Source/Login/ViewController/HistoryManagement/PortfolioViewController.swift
+++ b/Budi/Budi/Source/Login/ViewController/HistoryManagement/PortfolioViewController.swift
@@ -9,9 +9,15 @@ import UIKit
 import Combine
 import CombineCocoa
 
+protocol PortfolioViewControllerDelegate: AnyObject {
+    func getPortfolio(_ portfolio: SignupInfoModel)
+}
+
 class PortfolioViewController: UIViewController {
 
+    weak var delegate: PortfolioViewControllerDelegate?
     weak var coordinator: LoginCoordinator?
+    weak var myBudiCoordinator: MyBudiCoordinator?
     @IBOutlet weak var modalView: UIView!
     var viewModel: SignupViewModel
     @IBOutlet weak var emptyViewButton: UIButton!
@@ -61,16 +67,26 @@ class PortfolioViewController: UIViewController {
                 guard let text = text else { return }
                 guard var data = self?.viewModel.state.writedInfoData.value else { return }
                 data.porflioLink = text
+                print(data.porflioLink)
                 self?.viewModel.state.writedInfoData.send(data)
+                
             }
             .store(in: &cancellables)
 
         saveButton.tapPublisher
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
-                self?.viewModel.action.fetchSignupInfoData.send(())
+                guard let self = self else { return }
+                if self.myBudiCoordinator != nil {
+                    let send = self.viewModel.state.writedPortfolioData.value
+                    print("입력받은 텍스트", send)
+                    self.delegate?.getPortfolio(send)
+                } else {
+                    self.viewModel.action.fetchSignupInfoData.send(())
+                }
+
                 NotificationCenter.default.post(name: Notification.Name("Dismiss"), object: self)
-                self?.dismiss(animated: true, completion: nil)
+                self.dismiss(animated: true, completion: nil)
             }
             .store(in: &cancellables)
 

--- a/Budi/Budi/Source/Login/ViewController/PersonalInformation/PersonalInformationViewController.swift
+++ b/Budi/Budi/Source/Login/ViewController/PersonalInformation/PersonalInformationViewController.swift
@@ -101,7 +101,7 @@ class PersonalInformationViewController: UIViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] flag in
                 guard let self = self else { return }
-                guard let flag = flag else { return }
+                //guard let flag = flag else { return }
                 self.nickNameView.checkID(flag: flag)
             }
             .store(in: &cancellables)
@@ -138,11 +138,12 @@ class PersonalInformationViewController: UIViewController {
                 var changeData = self.viewModel.state.signUpPersonalInfoData.value
                 guard let text = text else { return }
                 changeData.nickName = text
-                if text == "" {
-                    self.nickNameView.emptyText()
+                if text == "" || text.count < 3 {
+                    self.nickNameView.emptyText(text: text)
+                } else {
+                    self.viewModel.action.checkSameId.send(text)
+                    self.viewModel.state.signUpPersonalInfoData.send(changeData)
                 }
-                self.viewModel.action.checkSameId.send(text)
-                self.viewModel.state.signUpPersonalInfoData.send(changeData)
             }
             .store(in: &cancellables)
 

--- a/Budi/Budi/Source/Login/ViewModel/SignupViewModel.swift
+++ b/Budi/Budi/Source/Login/ViewModel/SignupViewModel.swift
@@ -362,6 +362,7 @@ final class SignupViewModel: ViewModel {
 
                 let param = CreateInfo(
                     basePosition: self.state.selectedPosition.value.integerValue,
+                    imgUrl: "https://budi.s3.ap-northeast-2.amazonaws.com/post_image/default/dating.jpg",
                     careerList: uploadCareerList,
                     description: self.state.signUpPersonalInfoData.value.description,
                     memberAddress: self.state.signUpPersonalInfoData.value.location,

--- a/Budi/Budi/Source/Models/CreateInfo.swift
+++ b/Budi/Budi/Source/Models/CreateInfo.swift
@@ -8,6 +8,7 @@ import Foundation
 // MARK: - CreateInfo
 struct CreateInfo: Codable {
     let basePosition: Int
+    let imgUrl: String
     let careerList: [CareerList]
     let description, memberAddress, nickName: String
     let portfolioLink, positionList: [String]
@@ -17,6 +18,7 @@ struct CreateInfo: Codable {
         case basePosition, careerList
         case description
         case memberAddress, nickName, portfolioLink, positionList, projectList
+        case imgUrl
     }
 }
 

--- a/Budi/Budi/Source/Models/LoginUserDetail.swift
+++ b/Budi/Budi/Source/Models/LoginUserDetail.swift
@@ -9,14 +9,15 @@ import Foundation
 
 struct LoginUserDetail: Codable {
     let id: Int
-    let imageUrl: String?
-    let nickName: String
-    let description: String
+    var imageUrl: String?
+    var nickName: String
+    var address: String
+    var description: String
     let level: String
-    let positions: [String]
+    var positions: [String]
     let likeCount: Int
-    let projectList: [ProjectList]
-    let portfolioList: [String]
+    var projectList: [ProjectList]
+    var portfolioList: [String]
     let isLikedFromCurrentMember: Bool
 }
 
@@ -26,8 +27,8 @@ struct LoginCheckModel: Codable {
 
 struct ProjectList: Codable {
     let projectId: Int
-    let name: String
-    let startDate: String
-    let endDate: String
-    let description: String
+    var name: String
+    var startDate: String
+    var endDate: String
+    var description: String
 }

--- a/Budi/Budi/Source/Models/LoginUserDetail.swift
+++ b/Budi/Budi/Source/Models/LoginUserDetail.swift
@@ -9,11 +9,12 @@ import Foundation
 
 struct LoginUserDetail: Codable {
     let id: Int
-    var imageUrl: String?
+    var imgUrl: String
     var nickName: String
     var address: String
     var description: String
     let level: String
+    var basePosition: Int
     var positions: [String]
     let likeCount: Int
     var projectList: [ProjectList]

--- a/Budi/Budi/Source/Models/PositionSwitch.swift
+++ b/Budi/Budi/Source/Models/PositionSwitch.swift
@@ -1,0 +1,13 @@
+//
+//  PositionSwitch.swift
+//  Budi
+//
+//  Created by 인병윤 on 2022/01/11.
+//
+
+import Foundation
+
+enum PositionSwitch {
+    case writing
+    case myBudi
+}

--- a/Budi/Budi/Source/MyBudi/Edit/Cells/LocationReplaceTableViewCell.swift
+++ b/Budi/Budi/Source/MyBudi/Edit/Cells/LocationReplaceTableViewCell.swift
@@ -1,0 +1,39 @@
+//
+//  PositionTableViewCell.swift
+//  Budi
+//
+//  Created by 인병윤 on 2022/01/10.
+//
+
+import UIKit
+import Combine
+
+class LocationReplaceTableViewCell: UITableViewCell {
+
+    static let cellId = "LocationReplaceTableViewCell"
+    var cancellables = Set<AnyCancellable>()
+
+    @IBOutlet weak var locationTextField: UITextField!
+    @IBOutlet weak var replaceLocationButton: UIButton!
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        cancellables.removeAll()
+    }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+    func configureLocation(location: String) {
+        locationTextField.text = location
+    }
+
+}

--- a/Budi/Budi/Source/MyBudi/Edit/Cells/LocationReplaceTableViewCell.xib
+++ b/Budi/Budi/Source/MyBudi/Edit/Cells/LocationReplaceTableViewCell.xib
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="LocationReplaceTableViewCell" rowHeight="110" id="KGk-i7-Jjw" customClass="LocationReplaceTableViewCell" customModule="Budi" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="165"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="375" height="165"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FxT-Va-Dqg">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="165"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="활동지역" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jCU-Fb-r7H">
+                        <rect key="frame" x="16" y="16" width="48.5" height="17"/>
+                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gry-dR-8wz">
+                        <rect key="frame" x="16" y="105" width="343" height="48"/>
+                        <color key="backgroundColor" name="Border"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="48" id="ayI-mE-M7a"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                        <color key="tintColor" name="Black"/>
+                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                        <state key="normal" title="다시 선택">
+                            <color key="titleColor" red="0.40000000000000002" green="0.40000000000000002" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
+                        </state>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                <real key="value" value="8"/>
+                            </userDefinedRuntimeAttribute>
+                        </userDefinedRuntimeAttributes>
+                    </button>
+                    <textField opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="yEt-5g-y2m">
+                        <rect key="frame" x="16" y="49" width="343" height="48"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="48" id="YLm-Aj-sbr"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                        <textInputTraits key="textInputTraits"/>
+                        <connections>
+                            <action selector="locationTextField:" destination="KGk-i7-Jjw" eventType="editingDidEnd" id="7ls-DA-j6T"/>
+                        </connections>
+                    </textField>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="trailing" secondItem="yEt-5g-y2m" secondAttribute="trailing" constant="16" id="0vH-1m-iNA"/>
+                    <constraint firstItem="FxT-Va-Dqg" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="3i3-Wc-WI9"/>
+                    <constraint firstAttribute="trailing" secondItem="gry-dR-8wz" secondAttribute="trailing" constant="16" id="7mp-Md-oZy"/>
+                    <constraint firstItem="gry-dR-8wz" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="J6F-BD-fSR"/>
+                    <constraint firstAttribute="trailing" secondItem="FxT-Va-Dqg" secondAttribute="trailing" id="OV3-8d-jbS"/>
+                    <constraint firstAttribute="bottom" secondItem="FxT-Va-Dqg" secondAttribute="bottom" id="UWq-QQ-nNV"/>
+                    <constraint firstItem="jCU-Fb-r7H" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="WEK-xf-fOe"/>
+                    <constraint firstItem="gry-dR-8wz" firstAttribute="top" secondItem="yEt-5g-y2m" secondAttribute="bottom" constant="8" id="ge0-Bm-Eak"/>
+                    <constraint firstItem="FxT-Va-Dqg" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="hPj-m5-whX"/>
+                    <constraint firstItem="yEt-5g-y2m" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="l7F-BD-O8b"/>
+                    <constraint firstItem="jCU-Fb-r7H" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="ss3-Jx-1nx"/>
+                    <constraint firstItem="yEt-5g-y2m" firstAttribute="top" secondItem="jCU-Fb-r7H" secondAttribute="bottom" constant="16" id="uGh-N8-Ha7"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="locationTextField" destination="yEt-5g-y2m" id="vdn-MC-ec5"/>
+                <outlet property="replaceLocationButton" destination="gry-dR-8wz" id="QFC-hl-qs3"/>
+            </connections>
+            <point key="canvasLocation" x="160.86956521739131" y="105.80357142857143"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <namedColor name="Black">
+            <color red="0.11699999868869781" green="0.11699999868869781" blue="0.11699999868869781" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="Border">
+            <color red="0.87800002098083496" green="0.87800002098083496" blue="0.87800002098083496" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Budi/Budi/Source/MyBudi/Edit/Cells/MyBudiEditHeaderView.swift
+++ b/Budi/Budi/Source/MyBudi/Edit/Cells/MyBudiEditHeaderView.swift
@@ -1,0 +1,23 @@
+//
+//  MyBudiEditHeaderView.swift
+//  Budi
+//
+//  Created by 인병윤 on 2022/01/10.
+//
+
+import UIKit
+
+class MyBudiEditHeaderView: UITableViewHeaderFooterView {
+
+    static let cellId  = "MyBudiEditHeaderView"
+
+    @IBOutlet weak var headerLabel: UILabel!
+    override func prepareForReuse() {
+        super.prepareForReuse()
+
+    }
+
+    func configureHeader(header: String) {
+        headerLabel.text = header
+    }
+}

--- a/Budi/Budi/Source/MyBudi/Edit/Cells/MyBudiEditHeaderView.xib
+++ b/Budi/Budi/Source/MyBudi/Edit/Cells/MyBudiEditHeaderView.xib
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="MyBudiEditHeaderView" customModule="Budi" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="g14-BE-BbO">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="프로젝트" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mFA-6Q-qhF">
+                            <rect key="frame" x="16" y="15" width="48.5" height="17"/>
+                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstItem="mFA-6Q-qhF" firstAttribute="top" secondItem="g14-BE-BbO" secondAttribute="top" constant="15" id="jkf-eZ-s8R"/>
+                        <constraint firstItem="mFA-6Q-qhF" firstAttribute="leading" secondItem="g14-BE-BbO" secondAttribute="leading" constant="16" id="xYV-qV-EHA"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="g14-BE-BbO" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="ON5-5h-UTL"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="g14-BE-BbO" secondAttribute="bottom" id="cWd-WF-8Hc"/>
+                <constraint firstItem="g14-BE-BbO" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="nYp-fV-nYv"/>
+                <constraint firstAttribute="trailing" secondItem="g14-BE-BbO" secondAttribute="trailing" id="ndk-yP-Eth"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="headerLabel" destination="mFA-6Q-qhF" id="6Vo-Vg-2WG"/>
+            </connections>
+            <point key="canvasLocation" x="226.81159420289856" y="316.07142857142856"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Budi/Budi/Source/MyBudi/Edit/Cells/NormalTextFieldTableViewCell.swift
+++ b/Budi/Budi/Source/MyBudi/Edit/Cells/NormalTextFieldTableViewCell.swift
@@ -1,0 +1,41 @@
+//
+//  NormalTextFieldTableViewCell.swift
+//  Budi
+//
+//  Created by 인병윤 on 2022/01/10.
+//
+
+import UIKit
+import Combine
+
+class NormalTextFieldTableViewCell: UITableViewCell {
+
+    static let cellId = "NormalTextFieldTableViewCell"
+    var cancellables = Set<AnyCancellable>()
+    @IBOutlet weak var normalTextField: UITextField!
+    @IBOutlet weak var normalTitleLabel: UILabel!
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        cancellables.removeAll()
+    }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+    func configureText(text: String) {
+        normalTextField.text = text
+    }
+
+    func configureLabel(text: String) {
+        normalTitleLabel.text = text
+    }
+}

--- a/Budi/Budi/Source/MyBudi/Edit/Cells/NormalTextFieldTableViewCell.swift
+++ b/Budi/Budi/Source/MyBudi/Edit/Cells/NormalTextFieldTableViewCell.swift
@@ -14,7 +14,7 @@ class NormalTextFieldTableViewCell: UITableViewCell {
     var cancellables = Set<AnyCancellable>()
     @IBOutlet weak var normalTextField: UITextField!
     @IBOutlet weak var normalTitleLabel: UILabel!
-
+    
     override func prepareForReuse() {
         super.prepareForReuse()
         cancellables.removeAll()

--- a/Budi/Budi/Source/MyBudi/Edit/Cells/NormalTextFieldTableViewCell.xib
+++ b/Budi/Budi/Source/MyBudi/Edit/Cells/NormalTextFieldTableViewCell.xib
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="NormalTextFieldTableViewCell" id="KGk-i7-Jjw" customClass="NormalTextFieldTableViewCell" customModule="Budi" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="109"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="375" height="109"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Cee-JH-ai9">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="109"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MainTitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Kl-4G-e9g">
+                                <rect key="frame" x="16" y="20" width="61.5" height="17"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="sOm-rs-puA">
+                                <rect key="frame" x="16" y="50" width="343" height="48"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="48" id="rLN-Eh-QjN"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="6Kl-4G-e9g" firstAttribute="top" secondItem="Cee-JH-ai9" secondAttribute="top" constant="20" id="Gfj-Zb-bsU"/>
+                            <constraint firstItem="6Kl-4G-e9g" firstAttribute="leading" secondItem="Cee-JH-ai9" secondAttribute="leading" constant="16" id="QFi-gf-6Ks"/>
+                            <constraint firstAttribute="trailing" secondItem="sOm-rs-puA" secondAttribute="trailing" constant="16" id="TML-L7-2AH"/>
+                            <constraint firstItem="sOm-rs-puA" firstAttribute="leading" secondItem="Cee-JH-ai9" secondAttribute="leading" constant="16" id="qUr-Jc-bjw"/>
+                            <constraint firstAttribute="bottom" secondItem="sOm-rs-puA" secondAttribute="bottom" constant="11" id="tkY-7h-GNQ"/>
+                        </constraints>
+                    </view>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="trailing" secondItem="Cee-JH-ai9" secondAttribute="trailing" id="4HI-K8-79d"/>
+                    <constraint firstAttribute="bottom" secondItem="Cee-JH-ai9" secondAttribute="bottom" id="5cZ-WA-4vP"/>
+                    <constraint firstItem="Cee-JH-ai9" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="pGa-SR-g6Y"/>
+                    <constraint firstItem="Cee-JH-ai9" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="rUN-mt-4jz"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="normalTextField" destination="sOm-rs-puA" id="OMS-VP-Fdz"/>
+                <outlet property="normalTitleLabel" destination="6Kl-4G-e9g" id="rHW-Lc-tts"/>
+            </connections>
+            <point key="canvasLocation" x="132.60869565217394" y="83.370535714285708"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Budi/Budi/Source/MyBudi/Edit/Cells/PositionTableViewCell.swift
+++ b/Budi/Budi/Source/MyBudi/Edit/Cells/PositionTableViewCell.swift
@@ -33,11 +33,12 @@ class PositionTableViewCell: UITableViewCell {
     }
 
     func configurePosition(position: [String]) {
-        var positionText = ""
-        for position in position {
-            positionText += "#\(position) "
+        if position.count != 0 {
+            var positionText = ""
+            for position in position {
+                positionText += "#\(position) "
+            }
+            positionTextField.text = positionText
         }
-        positionTextField.text = positionText
     }
 }
-

--- a/Budi/Budi/Source/MyBudi/Edit/Cells/PositionTableViewCell.swift
+++ b/Budi/Budi/Source/MyBudi/Edit/Cells/PositionTableViewCell.swift
@@ -1,0 +1,43 @@
+//
+//  PositionTableViewCell.swift
+//  Budi
+//
+//  Created by 인병윤 on 2022/01/10.
+//
+
+import UIKit
+import Combine
+
+class PositionTableViewCell: UITableViewCell {
+
+    static let cellId = "PositionTableViewCell"
+    var cancellables = Set<AnyCancellable>()
+
+    @IBOutlet weak var positionTextField: UITextField!
+
+    @IBOutlet weak var positionEditButton: UIButton!
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        cancellables.removeAll()
+    }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+    func configurePosition(position: [String]) {
+        var positionText = ""
+        for position in position {
+            positionText += "#\(position) "
+        }
+        positionTextField.text = positionText
+    }
+}
+

--- a/Budi/Budi/Source/MyBudi/Edit/Cells/PositionTableViewCell.xib
+++ b/Budi/Budi/Source/MyBudi/Edit/Cells/PositionTableViewCell.xib
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="PositionTableViewCell" rowHeight="49" id="KGk-i7-Jjw" customClass="PositionTableViewCell" customModule="Budi" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="109"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="375" height="109"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7n8-UR-kYi">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="109"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="상세직무" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Aou-ZQ-PdT">
+                        <rect key="frame" x="16" y="20" width="48.5" height="17"/>
+                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="QZj-ka-GdP">
+                        <rect key="frame" x="16" y="50" width="343" height="48"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="48" id="Lof-OD-fTV"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <textInputTraits key="textInputTraits"/>
+                    </textField>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="l0g-v4-DR7">
+                        <rect key="frame" x="16" y="50" width="343" height="53"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="53" id="1K9-6B-Oqy"/>
+                            <constraint firstAttribute="width" constant="343" id="Car-zd-AE9"/>
+                        </constraints>
+                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                    </button>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="trailing" secondItem="7n8-UR-kYi" secondAttribute="trailing" id="0wU-9p-a4w"/>
+                    <constraint firstItem="QZj-ka-GdP" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="1dW-jY-XPa"/>
+                    <constraint firstAttribute="trailing" secondItem="QZj-ka-GdP" secondAttribute="trailing" constant="16" id="1zn-Gi-gTH"/>
+                    <constraint firstItem="Aou-ZQ-PdT" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="4DH-Ms-exd"/>
+                    <constraint firstAttribute="bottom" secondItem="7n8-UR-kYi" secondAttribute="bottom" id="E7e-Zg-z1L"/>
+                    <constraint firstItem="Aou-ZQ-PdT" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="20" id="N1X-70-QSk"/>
+                    <constraint firstItem="l0g-v4-DR7" firstAttribute="top" secondItem="Aou-ZQ-PdT" secondAttribute="bottom" constant="13" id="Ubz-zF-UA5"/>
+                    <constraint firstItem="l0g-v4-DR7" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="YmZ-lJ-IEF"/>
+                    <constraint firstAttribute="bottom" secondItem="l0g-v4-DR7" secondAttribute="bottom" constant="6" id="eAs-gk-l4M"/>
+                    <constraint firstAttribute="bottom" secondItem="QZj-ka-GdP" secondAttribute="bottom" constant="11" id="eYn-xC-uqe"/>
+                    <constraint firstItem="7n8-UR-kYi" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="oC1-45-vFC"/>
+                    <constraint firstAttribute="trailing" secondItem="l0g-v4-DR7" secondAttribute="trailing" constant="16" id="pb6-Sl-aEb"/>
+                    <constraint firstItem="7n8-UR-kYi" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="rPb-Kk-OWM"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="positionEditButton" destination="l0g-v4-DR7" id="8Te-Qu-jGB"/>
+                <outlet property="positionTextField" destination="QZj-ka-GdP" id="8TT-w4-iE1"/>
+            </connections>
+            <point key="canvasLocation" x="141.30434782608697" y="82.03125"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Budi/Budi/Source/MyBudi/Edit/Cells/ProjectTableViewCell.swift
+++ b/Budi/Budi/Source/MyBudi/Edit/Cells/ProjectTableViewCell.swift
@@ -1,0 +1,50 @@
+//
+//  ProjectTableViewCell.swift
+//  Budi
+//
+//  Created by 인병윤 on 2022/01/10.
+//
+
+import UIKit
+import Combine
+
+class ProjectTableViewCell: UITableViewCell {
+
+    var cancellables = Set<AnyCancellable>()
+    static let cellId = "ProjectTableViewCell"
+
+    @IBOutlet weak var selectMainTitleLabel: UILabel!
+    @IBOutlet weak var selectDayLabel: UILabel!
+    @IBOutlet weak var selectView: UIView!
+    @IBOutlet weak var addButton: UIButton!
+    @IBOutlet weak var moreButton: UIButton!
+    @IBOutlet weak var selectTeamLabel: UILabel!
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        cancellables.removeAll()
+    }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        selectView.isHidden = true
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+    func configureLabel(main: String, date: String, sub: String) {
+        selectView.isHidden = false
+        selectMainTitleLabel.text = main
+        selectDayLabel.text = date
+        selectTeamLabel.text = sub
+        self.bringSubviewToFront(moreButton)
+    }
+
+    func configureButtonTitle(text: String) {
+        addButton.setTitle(text, for: .normal)
+    }
+}

--- a/Budi/Budi/Source/MyBudi/Edit/Cells/ProjectTableViewCell.swift
+++ b/Budi/Budi/Source/MyBudi/Edit/Cells/ProjectTableViewCell.swift
@@ -22,6 +22,7 @@ class ProjectTableViewCell: UITableViewCell {
 
     override func prepareForReuse() {
         super.prepareForReuse()
+        selectView.isHidden = true
         cancellables.removeAll()
     }
 

--- a/Budi/Budi/Source/MyBudi/Edit/Cells/ProjectTableViewCell.xib
+++ b/Budi/Budi/Source/MyBudi/Edit/Cells/ProjectTableViewCell.xib
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="ProjectTableViewCell" id="KGk-i7-Jjw" customClass="ProjectTableViewCell" customModule="Budi" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="90"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="414" height="90"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EYL-Dh-syn">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="90"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <button opaque="NO" alpha="0.87000000476837158" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LU2-lZ-Zhf">
+                        <rect key="frame" x="8" y="5" width="398" height="80"/>
+                        <color key="backgroundColor" name="Primary_sub"/>
+                        <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="0.87" colorSpace="custom" customColorSpace="displayP3"/>
+                        <state key="normal" title="Button"/>
+                        <buttonConfiguration key="configuration" style="plain" image="locationAddButton" title="경력을 추가해보세요"/>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                <real key="value" value="8"/>
+                            </userDefinedRuntimeAttribute>
+                        </userDefinedRuntimeAttributes>
+                    </button>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fbB-0h-3yD">
+                        <rect key="frame" x="8" y="5" width="398" height="80"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ara-Ev-SOe">
+                                <rect key="frame" x="16" y="14" width="37" height="19.5"/>
+                                <fontDescription key="fontDescription" name="AppleSDGothicNeo-SemiBold" family="Apple SD Gothic Neo" pointSize="16"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2021.10 ~ 2021.11" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7V2-sU-Hkz">
+                                <rect key="frame" x="16" y="37.5" width="102" height="17"/>
+                                <fontDescription key="fontDescription" name="AppleSDGothicNeo-Regular" family="Apple SD Gothic Neo" pointSize="14"/>
+                                <color key="textColor" white="0.0" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="모바일서비스팀" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JNy-DO-6uM">
+                                <rect key="frame" x="16" y="58.5" width="85" height="17"/>
+                                <fontDescription key="fontDescription" name="AppleSDGothicNeo-Regular" family="Apple SD Gothic Neo" pointSize="14"/>
+                                <color key="textColor" white="0.0" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="j72-4y-8O2">
+                                <rect key="frame" x="358" y="30" width="19" height="22"/>
+                                <color key="tintColor" name="DarkGray"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" image="ellipsis" catalog="system"/>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="7V2-sU-Hkz" firstAttribute="leading" secondItem="fbB-0h-3yD" secondAttribute="leading" constant="16" id="14P-aG-SNR"/>
+                            <constraint firstItem="j72-4y-8O2" firstAttribute="top" secondItem="fbB-0h-3yD" secondAttribute="top" constant="30" id="5Z0-df-JuG"/>
+                            <constraint firstItem="7V2-sU-Hkz" firstAttribute="top" secondItem="ara-Ev-SOe" secondAttribute="bottom" constant="4" id="A3w-tL-eQH"/>
+                            <constraint firstItem="JNy-DO-6uM" firstAttribute="top" secondItem="7V2-sU-Hkz" secondAttribute="bottom" constant="4" id="VyY-JB-LBw"/>
+                            <constraint firstItem="ara-Ev-SOe" firstAttribute="leading" secondItem="fbB-0h-3yD" secondAttribute="leading" constant="16" id="X0H-EL-Lts"/>
+                            <constraint firstAttribute="trailing" secondItem="j72-4y-8O2" secondAttribute="trailing" constant="21" id="X8H-GR-GPV"/>
+                            <constraint firstItem="ara-Ev-SOe" firstAttribute="top" secondItem="fbB-0h-3yD" secondAttribute="top" constant="14" id="bYD-os-Yzz"/>
+                            <constraint firstItem="JNy-DO-6uM" firstAttribute="leading" secondItem="fbB-0h-3yD" secondAttribute="leading" constant="16" id="ndI-yv-51C"/>
+                        </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                <color key="value" white="0.0" alpha="0.12" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </userDefinedRuntimeAttribute>
+                            <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                <real key="value" value="1"/>
+                            </userDefinedRuntimeAttribute>
+                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                <real key="value" value="8"/>
+                            </userDefinedRuntimeAttribute>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="trailing" secondItem="fbB-0h-3yD" secondAttribute="trailing" constant="8" id="0W9-3M-Eig"/>
+                    <constraint firstAttribute="trailing" secondItem="LU2-lZ-Zhf" secondAttribute="trailing" constant="8" id="FTH-6s-0eH"/>
+                    <constraint firstItem="LU2-lZ-Zhf" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="8" id="K8N-Nz-pal"/>
+                    <constraint firstItem="fbB-0h-3yD" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="5" id="XQS-XS-7aX"/>
+                    <constraint firstItem="fbB-0h-3yD" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="8" id="YCU-7g-6lr"/>
+                    <constraint firstAttribute="bottom" secondItem="fbB-0h-3yD" secondAttribute="bottom" constant="5" id="bAH-QT-8CN"/>
+                    <constraint firstAttribute="bottom" secondItem="LU2-lZ-Zhf" secondAttribute="bottom" constant="5" id="cFJ-j0-gvp"/>
+                    <constraint firstItem="LU2-lZ-Zhf" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="5" id="lTI-cY-Xfk"/>
+                    <constraint firstItem="EYL-Dh-syn" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="mHV-oR-8iM"/>
+                    <constraint firstAttribute="bottom" secondItem="EYL-Dh-syn" secondAttribute="bottom" id="oEK-Xb-N7v"/>
+                    <constraint firstItem="EYL-Dh-syn" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="pXg-70-B3q"/>
+                    <constraint firstAttribute="trailing" secondItem="EYL-Dh-syn" secondAttribute="trailing" id="x4a-A1-27M"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="addButton" destination="LU2-lZ-Zhf" id="YTj-77-qa5"/>
+                <outlet property="moreButton" destination="j72-4y-8O2" id="hPx-zS-DA7"/>
+                <outlet property="selectDayLabel" destination="7V2-sU-Hkz" id="29v-KP-qnh"/>
+                <outlet property="selectMainTitleLabel" destination="ara-Ev-SOe" id="9j2-Y4-rSU"/>
+                <outlet property="selectTeamLabel" destination="JNy-DO-6uM" id="G0t-iF-Uiw"/>
+                <outlet property="selectView" destination="fbB-0h-3yD" id="xWl-fZ-s9e"/>
+            </connections>
+            <point key="canvasLocation" x="131.8840579710145" y="79.6875"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <image name="ellipsis" catalog="system" width="128" height="37"/>
+        <image name="locationAddButton" width="24" height="24"/>
+        <namedColor name="DarkGray">
+            <color red="0.36000001430511475" green="0.36000001430511475" blue="0.36000001430511475" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="Primary_sub">
+            <color red="0.92549019607843142" green="0.92941176470588238" blue="0.98039215686274506" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Budi/Budi/Source/MyBudi/Edit/MyBudiEditViewController.swift
+++ b/Budi/Budi/Source/MyBudi/Edit/MyBudiEditViewController.swift
@@ -70,8 +70,6 @@ final class MyBudiEditViewController: UIViewController {
             }
             .store(in: &cancellables)
 
-
-
     }
 
     func modalViewBackgoundOn() {
@@ -291,7 +289,7 @@ extension MyBudiEditViewController: UITableViewDelegate, UITableViewDataSource {
                 } else {
                     cell.configureLabel(text: "한줄소개")
                     cell.configureText(text: self.viewModel.state.loginUserData.value?.description ?? "")
-
+                    
                     cell.normalTextField.textPublisher
                         .receive(on: DispatchQueue.main)
                         .sink { [weak self] text in

--- a/Budi/Budi/Source/MyBudi/Edit/MyBudiEditViewController.swift
+++ b/Budi/Budi/Source/MyBudi/Edit/MyBudiEditViewController.swift
@@ -11,10 +11,11 @@ import CombineCocoa
 
 final class MyBudiEditViewController: UIViewController {
      
+    @IBOutlet weak var tableView: UITableView!
     weak var coordinator: MyBudiCoordinator?
-    private let viewModel: MyBudiEditViewModel
+    var viewModel: MyBudiEditViewModel
     private var cancellables = Set<AnyCancellable>()
-    
+    var location: String = "충남 당진시"
     init(nibName: String?, bundle: Bundle?, viewModel: MyBudiEditViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nibName, bundle: bundle)
@@ -27,7 +28,10 @@ final class MyBudiEditViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureNavigationBar()
-        configureCollectionView()
+        configureTableView()
+        setPublisher()
+        print(viewModel.state.mySectionData.value)
+        print(viewModel.state.mySectionData.value[1].items.count)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -37,12 +41,73 @@ final class MyBudiEditViewController: UIViewController {
     override func viewWillDisappear(_ animated: Bool) {
         tabBarController?.tabBar.isHidden = false
     }
+
+    func setPublisher() {
+        NotificationCenter.default.publisher(for: Notification.Name("Dismiss"))
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.modalViewBackgoundOff()
+            }
+            .store(in: &cancellables)
+    }
+
+    func modalViewBackgoundOn() {
+        UIView.animate(withDuration: 0.4, delay: 0, options: .curveEaseOut, animations: {
+            self.view.alpha = 0.5
+        })
+    }
+
+    func modalViewBackgoundOff() {
+        UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseOut, animations: {
+            self.view.alpha = 1.0
+        })
+    }
+
+    private func showActionSheet(section: Int, index: Int) {
+        let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+
+        let edit = UIAlertAction(title: "수정", style: .default, handler: { [weak self] _ in
+            guard let self = self else { return }
+            self.modalViewBackgoundOn()
+            if section == 0 {
+                self.coordinator?.showProjectViewController(self, viewModel: self.viewModel)
+            } else if section == 1 {
+                self.coordinator?.showPortfolioController(self,viewModel: self.viewModel)
+            }
+        })
+        let delete = UIAlertAction(title: "삭제", style: .destructive, handler: { _ in
+        })
+
+        let cancel = UIAlertAction(title: "완료", style: .cancel, handler: { _ in
+            print(section, index)
+        })
+
+        actionSheet.addAction(edit)
+        actionSheet.addAction(delete)
+        actionSheet.addAction(cancel)
+
+        present(actionSheet, animated: true, completion: nil)
+    }
 }
 
 // MARK: - CollectionView
 extension MyBudiEditViewController {
-    private func configureCollectionView() {
-        
+    private func configureTableView() {
+        tableView.delegate = self
+        tableView.dataSource = self
+        let nib = UINib(nibName: MyBudiEditHeaderView.cellId, bundle: nil)
+        let normal = UINib(nibName: NormalTextFieldTableViewCell.cellId, bundle: nil)
+        let location = UINib(nibName: LocationReplaceTableViewCell.cellId, bundle: nil)
+        let position = UINib(nibName: PositionTableViewCell.cellId, bundle: nil)
+        let project = UINib(nibName: ProjectTableViewCell.cellId, bundle: nil)
+        let portfolio = UINib(nibName: PortfolioURLTableViewCell.cellId, bundle: nil)
+        tableView.register(nib, forHeaderFooterViewReuseIdentifier: MyBudiEditHeaderView.cellId)
+        tableView.register(normal, forCellReuseIdentifier: NormalTextFieldTableViewCell.cellId)
+        tableView.register(location, forCellReuseIdentifier: LocationReplaceTableViewCell.cellId)
+        tableView.register(position, forCellReuseIdentifier: PositionTableViewCell.cellId)
+        tableView.register(project, forCellReuseIdentifier: ProjectTableViewCell.cellId)
+        tableView.register(portfolio, forCellReuseIdentifier: PortfolioURLTableViewCell.cellId)
+        tableView.separatorStyle = UITableViewCell.SeparatorStyle.none
     }
 }
 
@@ -55,5 +120,221 @@ private extension MyBudiEditViewController {
 
         navigationItem.rightBarButtonItem =  UIBarButtonItem(customView: stackview)
         title = "프로필 수정"
+    }
+}
+
+extension MyBudiEditViewController: UITableViewDelegate, UITableViewDataSource {
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        if section == 0 {
+            return 4
+        } else if section == 1 {
+            return (viewModel.state.loginUserData.value?.projectList.count ?? 1) + 1
+        } else {
+            return (viewModel.state.loginUserData.value?.portfolioList.count ?? 1) + 1
+        }
+    }
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        if indexPath.section == 0 {
+            if indexPath.row == 1 {
+                return 165
+            } else {
+                return 109
+            }
+        } else if indexPath.section == 1 {
+            return 100
+        } else {
+            return 55
+        }
+    }
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        3
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        if section != 0 {
+            return 50
+        }
+        return 0
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        if section >= 1 {
+            guard let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: MyBudiEditHeaderView.cellId) as? MyBudiEditHeaderView else { return UIView() }
+            let title = viewModel.state.mySectionData.value[section-1].sectionTitle
+            print("섹션", section)
+            if section == 1 {
+                header.configureHeader(header: title)
+            } else {
+                header.configureHeader(header: title)
+            }
+            return header
+        }
+
+        return UIView()
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        if indexPath.section == 0 {
+            if indexPath.row == 0 || indexPath.row == 2 {
+                guard let cell = tableView.dequeueReusableCell(withIdentifier: NormalTextFieldTableViewCell.cellId, for: indexPath) as? NormalTextFieldTableViewCell else { return UITableViewCell() }
+
+                if indexPath.row == 0 {
+                    cell.configureLabel(text: "닉네임")
+                    cell.configureText(text: self.viewModel.state.loginUserData.value?.nickName ?? "")
+
+                    cell.normalTextField.textPublisher
+                        .receive(on: DispatchQueue.main)
+                        .sink { [weak self] text in
+                            guard let self = self else { return }
+                            var changeData = self.viewModel.state.loginUserData.value
+                            changeData?.nickName = text ?? ""
+                            self.viewModel.state.loginUserData.send(changeData)
+                            print(self.viewModel.state.loginUserData.value?.nickName ?? "")
+                        }
+                        .store(in: &cell.cancellables)
+                } else {
+                    cell.configureLabel(text: "한줄소개")
+                    cell.configureText(text: self.viewModel.state.loginUserData.value?.description ?? "")
+
+                    cell.normalTextField.textPublisher
+                        .receive(on: DispatchQueue.main)
+                        .sink { [weak self] text in
+                            guard let self = self else { return }
+                            var changeData = self.viewModel.state.loginUserData.value
+                            changeData?.description = text ?? ""
+                            self.viewModel.state.loginUserData.send(changeData)
+                            print(self.viewModel.state.loginUserData.value?.description ?? "")
+                        }
+                        .store(in: &cell.cancellables)
+                }
+
+                return cell
+            } else if indexPath.row == 1 {
+                guard let cell = tableView.dequeueReusableCell(withIdentifier: LocationReplaceTableViewCell.cellId, for: indexPath) as? LocationReplaceTableViewCell else { return UITableViewCell() }
+                cell.configureLocation(location: viewModel.state.loginUserData.value?.address ?? "")
+
+                cell.replaceLocationButton.tapPublisher
+                    .receive(on: DispatchQueue.main)
+                    .sink { [weak self] _ in
+                        guard let self = self else { return }
+                        self.coordinator?.showLocationSearchViewController(self)
+                    }
+                    .store(in: &cell.cancellables)
+
+                return cell
+            } else {
+                guard let cell = tableView.dequeueReusableCell(withIdentifier: PositionTableViewCell.cellId, for: indexPath) as? PositionTableViewCell else { return UITableViewCell() }
+                cell.configurePosition(position: viewModel.state.loginUserData.value?.positions ?? [])
+
+                cell.positionEditButton.tapPublisher
+                    .receive(on: DispatchQueue.main)
+                    .sink { [weak self] _ in
+                        guard let self = self else { return }
+                        self.coordinator?.showProjectMembersBottomViewController(self, self.viewModel)
+                    }
+                    .store(in: &cell.cancellables)
+                return cell
+            }
+        } else if indexPath.section == 1 {
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: ProjectTableViewCell.cellId, for: indexPath) as? ProjectTableViewCell else { return UITableViewCell() }
+            cell.configureButtonTitle(text: "프로젝트를 추가해 보세요")
+            if viewModel.state.loginUserData.value?.projectList.count != indexPath.row {
+                let data = viewModel.state.loginUserData.value?.projectList[indexPath.row]
+                if let data = data {
+                    cell.configureLabel(main: data.name, date: data.startDate + " ~ " + data.endDate, sub: data.description)
+                }
+            }
+
+            cell.addButton.tapPublisher
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in
+                    guard let self = self else { return }
+                    self.coordinatzor?.showProjectViewController(self, viewModel: self.viewModel)
+                    self.modalViewBackgoundOn()
+                }
+                .store(in: &cell.cancellables)
+
+            cell.moreButton.tapPublisher
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in
+                    guard let self = self else { return }
+                    self.coordinator?.showProjectViewController(self, viewModel: self.viewModel)
+                    self.modalViewBackgoundOn()
+                }
+                .store(in: &cell.cancellables)
+            
+            return cell
+        } else {
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: PortfolioURLTableViewCell.cellId, for: indexPath) as? PortfolioURLTableViewCell else { return UITableViewCell() }
+            if viewModel.state.loginUserData.value?.portfolioList.count != indexPath.row {
+                let data = viewModel.state.loginUserData.value?.portfolioList[indexPath.row]
+                if let data = data {
+                    cell.configureParsing(url: data)
+                }
+            } else {
+                cell.configureButtonLabel(text: "포트폴리오를 추가해 보세요")
+            }
+
+            cell.addButton.tapPublisher
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in
+                    guard let self = self else { return }
+                    self.coordinator?.showPortfolioController(self, viewModel: self.viewModel)
+                    self.modalViewBackgoundOn()
+                }
+                .store(in: &cell.cancellables)
+            return cell
+        }
+
+    }
+
+}
+
+extension MyBudiEditViewController: HomeLocationSearchViewControllerDelegate {
+    func getLocation(_ location: String) {
+        // 아직 API에서 지역을 뽑아와주지 않아서 일단 대기
+        var changeData = viewModel.state.loginUserData.value
+        changeData?.address = location
+        viewModel.state.loginUserData.send(changeData)
+        tableView.reloadData()
+    }
+
+}
+
+extension MyBudiEditViewController: ProjectMembersBottomViewControllerDelegate {
+    func getRecruitingPositions(_ recruitingPositions: [RecruitingPosition]) {
+        var changeData = viewModel.state.loginUserData.value
+        let position = recruitingPositions.map { $0.positionName }
+        changeData?.positions = position
+        viewModel.state.loginUserData.send(changeData)
+        tableView.reloadData()
+    }
+
+}
+
+extension MyBudiEditViewController: HistoryWriteViewControllerDelegate {
+    func getProject(_ project: SignupInfoModel?) {
+        var changeData = viewModel.state.loginUserData.value
+        var changeProject = ProjectList(projectId: 0,
+                                        name: project?.mainName ?? "",
+                                        startDate: project?.startDate ?? "",
+                                        endDate: project?.endDate ?? "",
+                                        description: project?.description ?? "")
+        changeData?.projectList.append(changeProject)
+        viewModel.state.loginUserData.send(changeData)
+        print(viewModel.state.loginUserData.value?.projectList)
+        tableView.reloadData()
+    }
+}
+
+
+extension MyBudiEditViewController: PortfolioViewControllerDelegate {
+    func getPortfolio(_ portfolio: SignupInfoModel) {
+        var changeData = viewModel.state.loginUserData.value
+        print("입력받은 포트폴리오", portfolio)
+
     }
 }

--- a/Budi/Budi/Source/MyBudi/Edit/MyBudiEditViewController.swift
+++ b/Budi/Budi/Source/MyBudi/Edit/MyBudiEditViewController.swift
@@ -49,6 +49,14 @@ final class MyBudiEditViewController: UIViewController {
                 self?.modalViewBackgoundOff()
             }
             .store(in: &cancellables)
+
+        viewModel.state.loginUserData
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                //
+            }
+            .store(in: &cancellables)
     }
 
     func modalViewBackgoundOn() {
@@ -252,7 +260,7 @@ extension MyBudiEditViewController: UITableViewDelegate, UITableViewDataSource {
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self] _ in
                     guard let self = self else { return }
-                    self.coordinatzor?.showProjectViewController(self, viewModel: self.viewModel)
+                    self.coordinator?.showProjectViewController(self, viewModel: self.viewModel)
                     self.modalViewBackgoundOn()
                 }
                 .store(in: &cell.cancellables)
@@ -330,11 +338,11 @@ extension MyBudiEditViewController: HistoryWriteViewControllerDelegate {
     }
 }
 
-
 extension MyBudiEditViewController: PortfolioViewControllerDelegate {
-    func getPortfolio(_ portfolio: SignupInfoModel) {
-        var changeData = viewModel.state.loginUserData.value
-        print("입력받은 포트폴리오", portfolio)
-
+    func getPortfolio(_ portfolio: SignupInfoModel?) {
+        guard var changeData = viewModel.state.loginUserData.value else { return }
+        changeData.portfolioList.append(portfolio?.porflioLink ?? "")
+        viewModel.state.loginUserData.send(changeData)
+        tableView.reloadData()
     }
 }

--- a/Budi/Budi/Source/MyBudi/Edit/MyBudiEditViewController.swift
+++ b/Budi/Budi/Source/MyBudi/Edit/MyBudiEditViewController.swift
@@ -403,10 +403,11 @@ extension MyBudiEditViewController: HomeLocationSearchViewControllerDelegate {
 }
 
 extension MyBudiEditViewController: ProjectMembersBottomViewControllerDelegate {
-    func getRecruitingPositions(_ recruitingPositions: [RecruitingPosition], _ selectPostion: Int) {
+    func getRecruitingPositions(_ recruitingPositions: [RecruitingPosition], _ selectPostion: Int?) {
         var changeData = viewModel.state.loginUserData.value
         let position = recruitingPositions.map { $0.positionName }
         changeData?.positions = position
+        guard let selectPostion = selectPostion else { return }
         changeData?.basePosition = selectPostion
         viewModel.state.loginUserData.send(changeData)
         tableView.reloadData()

--- a/Budi/Budi/Source/MyBudi/Edit/MyBudiEditViewController.xib
+++ b/Budi/Budi/Source/MyBudi/Edit/MyBudiEditViewController.xib
@@ -12,7 +12,9 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="MyBudiEditViewController" customModule="Budi" customModuleProvider="target">
             <connections>
+                <outlet property="imageEditButton" destination="KXH-7h-0vc" id="6gq-2w-KAA"/>
                 <outlet property="tableView" destination="GkF-Il-M7b" id="lox-VS-Tbf"/>
+                <outlet property="userImageView" destination="eTX-aD-ITv" id="RfL-Ef-zrj"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
@@ -38,6 +40,11 @@
                                             <constraint firstAttribute="width" constant="84" id="ks9-mY-VpJ"/>
                                             <constraint firstAttribute="height" constant="84" id="uap-xW-o17"/>
                                         </constraints>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                <real key="value" value="42"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
                                     </imageView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KXH-7h-0vc">
                                         <rect key="frame" x="139" y="116" width="96" height="30"/>

--- a/Budi/Budi/Source/MyBudi/Edit/MyBudiEditViewController.xib
+++ b/Budi/Budi/Source/MyBudi/Edit/MyBudiEditViewController.xib
@@ -1,22 +1,103 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="MyBudiEditViewController" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="MyBudiEditViewController" customModule="Budi" customModuleProvider="target">
             <connections>
+                <outlet property="tableView" destination="GkF-Il-M7b" id="lox-VS-Tbf"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="GkF-Il-M7b">
+                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                    <view key="tableHeaderView" contentMode="scaleToFill" id="bT9-zq-9ho">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="178"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WlS-E2-VhN">
+                                <rect key="frame" x="19.5" y="8" width="375" height="150"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="eTX-aD-ITv">
+                                        <rect key="frame" x="145" y="20" width="84" height="84"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="84" id="ks9-mY-VpJ"/>
+                                            <constraint firstAttribute="height" constant="84" id="uap-xW-o17"/>
+                                        </constraints>
+                                    </imageView>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KXH-7h-0vc">
+                                        <rect key="frame" x="139" y="116" width="96" height="30"/>
+                                        <color key="backgroundColor" name="Primary_sub"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="30" id="64z-aZ-VgA"/>
+                                            <constraint firstAttribute="width" constant="96" id="Cec-yG-sXW"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                        <state key="normal" title="사진 수정">
+                                            <color key="titleColor" name="Primary"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                <real key="value" value="8"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="375" id="3Cq-Ao-WhP"/>
+                                    <constraint firstAttribute="height" constant="150" id="LnQ-DV-YZY"/>
+                                    <constraint firstItem="eTX-aD-ITv" firstAttribute="leading" secondItem="WlS-E2-VhN" secondAttribute="leading" constant="145" id="ZOd-v2-F1O"/>
+                                    <constraint firstItem="eTX-aD-ITv" firstAttribute="top" secondItem="WlS-E2-VhN" secondAttribute="top" constant="20" id="ZTT-bH-Yfy"/>
+                                    <constraint firstItem="KXH-7h-0vc" firstAttribute="top" secondItem="eTX-aD-ITv" secondAttribute="bottom" constant="12" id="dZN-Sx-ruA"/>
+                                    <constraint firstItem="KXH-7h-0vc" firstAttribute="leading" secondItem="WlS-E2-VhN" secondAttribute="leading" constant="139" id="gsc-ah-wg7"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="WlS-E2-VhN" firstAttribute="top" secondItem="bT9-zq-9ho" secondAttribute="top" constant="8" id="MJs-gH-kXr"/>
+                            <constraint firstItem="WlS-E2-VhN" firstAttribute="centerX" secondItem="bT9-zq-9ho" secondAttribute="centerX" id="WAE-As-lwn"/>
+                        </constraints>
+                    </view>
+                    <sections/>
+                </tableView>
+            </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="GkF-Il-M7b" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="1gA-G1-fHv"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="GkF-Il-M7b" secondAttribute="bottom" id="Hce-fE-Xz8"/>
+                <constraint firstItem="GkF-Il-M7b" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="ces-AS-JLN"/>
+                <constraint firstItem="GkF-Il-M7b" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="jDw-9j-KiA"/>
+            </constraints>
+            <point key="canvasLocation" x="137.68115942028987" y="75"/>
         </view>
     </objects>
+    <resources>
+        <namedColor name="Primary">
+            <color red="0.36899998784065247" green="0.37299999594688416" blue="0.85900002717971802" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="Primary_sub">
+            <color red="0.92549019607843142" green="0.92941176470588238" blue="0.98039215686274506" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Budi/Budi/Source/MyBudi/Edit/MyBudiEditViewModel.swift
+++ b/Budi/Budi/Source/MyBudi/Edit/MyBudiEditViewModel.swift
@@ -15,6 +15,9 @@ class MyBudiEditViewModel: ViewModel {
         let fetch = PassthroughSubject<Void, Never>()
         let refresh = PassthroughSubject<Void, Never>()
         let switchView = PassthroughSubject<ModalControl, Never>()
+        let deleteProjectData = PassthroughSubject<Int, Never>()
+        let deletePortfolioData = PassthroughSubject<Int, Never>()
+        let postUserData = PassthroughSubject<Void, Never>()
     }
 
     struct State {
@@ -22,30 +25,8 @@ class MyBudiEditViewModel: ViewModel {
         let designerPositions = CurrentValueSubject<[String], Never>([])
         let productManagerPositions = CurrentValueSubject<[String], Never>([])
         let loginUserData = CurrentValueSubject<LoginUserDetail?, Never>(nil)
-        
-        let mySectionData = CurrentValueSubject<[HistorySectionModel], Never>(
-            [
-                HistorySectionModel.init(
-                    type: .project,
-                    sectionTitle: ModalControl.project.stringValue ,
-                    items: [
-                        Item(itemInfo: ItemInfo(isInclude: false, buttonTitle: "프로젝트 이력을 추가해보세요"),
-                             description: "", endDate: "", name: "", nowWork: false, startDate: "", portfolioLink: "")]),
-
-                HistorySectionModel.init(
-                    type: .portfolio,
-                    sectionTitle: ModalControl.portfolio.stringValue ,
-                    items: [
-                        Item(itemInfo: ItemInfo(isInclude: false, buttonTitle: "포트폴리오를 추가해보세요"),
-                             description: "", endDate: "", name: "", nowWork: false, startDate: "", portfolioLink: "")])
-            ])
-
-        let writedInfoData = CurrentValueSubject<SignupInfoModel?, Never>(
-            SignupInfoModel(mainName: "", startDate: "", endDate: "", nowWorks: false, description: "", porflioLink: "")
-        )
-        let writedPortfolioData = CurrentValueSubject<SignupInfoModel, Never>(
-            SignupInfoModel(mainName: "", startDate: "", endDate: "", nowWorks: false, description: "", porflioLink: "")
-        )
+        let dataChanged = CurrentValueSubject<Int, Never>(1)
+        let userInfoUploadStatus = CurrentValueSubject<String?, Never>(nil)
     }
 
     let action = Action()
@@ -90,11 +71,97 @@ class MyBudiEditViewModel: ViewModel {
 
             }).store(in: &cancellables)
 
+        action.deleteProjectData
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] idx in
+                guard let self = self else { return }
+                var changeData = self.state.loginUserData.value
+                changeData?.projectList.remove(at: idx)
+                self.state.loginUserData.send(changeData)
+                self.state.dataChanged.send(1)
+            }
+            .store(in: &cancellables)
+
+        action.deletePortfolioData
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] idx in
+                guard let self = self else { return }
+                var changeData = self.state.loginUserData.value
+                changeData?.portfolioList.remove(at: idx)
+                self.state.loginUserData.send(changeData)
+                self.state.dataChanged.send(2)
+            }
+            .store(in: &cancellables)
+
         action.refresh
             .sink { [weak self] _ in
                 self?.action.fetch.send(())
             }.store(in: &cancellables)
 
         action.fetch.send(())
+
+        action.postUserData
+            .receive(on: DispatchQueue.global())
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                guard let accsessToken = UserDefaults.standard.string(forKey: "accessToken") else { return }
+                let projectList = self.state.loginUserData.value?.projectList ?? []
+                let portfolioList = self.state.loginUserData.value?.portfolioList ?? []
+                var uploadCareerList: [CareerList] = []
+                var uploadProjectList: [TList] = []
+                var uploadPortfolioList: [String] = []
+                // 프로젝트 리스트 변환
+                for project in projectList {
+                    let tmp = TList(description: project.description,
+                                    endDate: project.endDate,
+                                    name: project.name,
+                                    startDate: project.startDate)
+                    if !tmp.name.isEmpty {
+                        uploadProjectList.append(tmp)
+                    }
+                }
+
+                // 포트폴리오 리스트 변환
+                for portfolio in portfolioList {
+                    uploadPortfolioList.append(portfolio)
+                }
+
+                let param = CreateInfo(
+                    basePosition: self.state.loginUserData.value?.basePosition ?? 0,
+                    imgUrl: self.state.loginUserData.value?.imgUrl ?? "",
+                    careerList: uploadCareerList,
+                    description: self.state.loginUserData.value?.description ?? "",
+                    memberAddress: self.state.loginUserData.value?.address ?? "",
+                    nickName: self.state.loginUserData.value?.nickName ?? "",
+                    portfolioLink: uploadPortfolioList,
+                    positionList: self.state.loginUserData.value?.positions ?? [],
+                    projectList: uploadProjectList
+                )
+                self.provider.requestPublisher(.createInfo(acessToken: accsessToken, param: param))
+                    .map(UserInfoUploadSuccess.self)
+                    .sink(receiveCompletion: { [weak self] completion in
+                        guard let self = self else { return }
+                        guard case let .failure(error) = completion else { return }
+                        self.state.userInfoUploadStatus.send(nil)
+                        print(error.localizedDescription)
+
+                    }, receiveValue: { post in
+                        self.state.userInfoUploadStatus.send(post.message)
+                        NotificationCenter.default.post(name: Notification.Name("LoginSuccessed"), object: nil)
+
+                    })
+                    .store(in: &self.cancellables)
+
+            }
+            .store(in: &cancellables)
+    }
+
+    func convertImageToURL(_ jpegData: Data, _ completion: @escaping (Result<Moya.Response, Error>) -> Void) {
+        provider.request(.convertImageToURL(jpegData: jpegData)) { result in
+            switch result {
+            case .success(let response): completion(.success(response))
+            case .failure(let error): completion(.failure(error))
+            }
+        }
     }
 }

--- a/Budi/Budi/Source/MyBudi/Edit/MyBudiEditViewModel.swift
+++ b/Budi/Budi/Source/MyBudi/Edit/MyBudiEditViewModel.swift
@@ -14,11 +14,40 @@ class MyBudiEditViewModel: ViewModel {
     struct Action {
         let fetch = PassthroughSubject<Void, Never>()
         let refresh = PassthroughSubject<Void, Never>()
+        let switchView = PassthroughSubject<ModalControl, Never>()
     }
 
     struct State {
+        let developerPositions = CurrentValueSubject<[String], Never>([])
+        let designerPositions = CurrentValueSubject<[String], Never>([])
+        let productManagerPositions = CurrentValueSubject<[String], Never>([])
+        let loginUserData = CurrentValueSubject<LoginUserDetail?, Never>(nil)
+        
+        let mySectionData = CurrentValueSubject<[HistorySectionModel], Never>(
+            [
+                HistorySectionModel.init(
+                    type: .project,
+                    sectionTitle: ModalControl.project.stringValue ,
+                    items: [
+                        Item(itemInfo: ItemInfo(isInclude: false, buttonTitle: "프로젝트 이력을 추가해보세요"),
+                             description: "", endDate: "", name: "", nowWork: false, startDate: "", portfolioLink: "")]),
+
+                HistorySectionModel.init(
+                    type: .portfolio,
+                    sectionTitle: ModalControl.portfolio.stringValue ,
+                    items: [
+                        Item(itemInfo: ItemInfo(isInclude: false, buttonTitle: "포트폴리오를 추가해보세요"),
+                             description: "", endDate: "", name: "", nowWork: false, startDate: "", portfolioLink: "")])
+            ])
+
+        let writedInfoData = CurrentValueSubject<SignupInfoModel?, Never>(
+            SignupInfoModel(mainName: "", startDate: "", endDate: "", nowWorks: false, description: "", porflioLink: "")
+        )
+        let writedPortfolioData = CurrentValueSubject<SignupInfoModel, Never>(
+            SignupInfoModel(mainName: "", startDate: "", endDate: "", nowWorks: false, description: "", porflioLink: "")
+        )
     }
-    
+
     let action = Action()
     let state = State()
     private var cancellables = Set<AnyCancellable>()
@@ -26,7 +55,39 @@ class MyBudiEditViewModel: ViewModel {
     
     init() {
         action.fetch
-            .sink(receiveValue: { _ in
+            .sink(receiveValue: { [weak self] _ in
+                guard let self = self else { return }
+                
+                self.provider
+                    .requestPublisher(.detailPositions(position: .developer))
+                    .map(APIResponse<[String]>.self)
+                    .map(\.data)
+                    .sink(receiveCompletion: { _ in
+                    }, receiveValue: { [weak self] positions in
+                        self?.state.developerPositions.send(positions)
+                    })
+                    .store(in: &self.cancellables)
+
+                self.provider
+                    .requestPublisher(.detailPositions(position: .designer))
+                    .map(APIResponse<[String]>.self)
+                    .map(\.data)
+                    .sink(receiveCompletion: { _ in
+                    }, receiveValue: { [weak self] positions in
+                        self?.state.designerPositions.send(positions)
+                    })
+                    .store(in: &self.cancellables)
+
+                self.provider
+                    .requestPublisher(.detailPositions(position: .productManager))
+                    .map(APIResponse<[String]>.self)
+                    .map(\.data)
+                    .sink(receiveCompletion: { _ in
+                    }, receiveValue: { [weak self] positions in
+                        self?.state.productManagerPositions.send(positions)
+                    })
+                    .store(in: &self.cancellables)
+
             }).store(in: &cancellables)
 
         action.refresh

--- a/Budi/Budi/Source/MyBudi/Level/MyBudiLevelViewController.swift
+++ b/Budi/Budi/Source/MyBudi/Level/MyBudiLevelViewController.swift
@@ -37,6 +37,37 @@ class MyBudiLevelViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureLayout()
+        configureLevelImage()
+    }
+
+    func configureLevelImage() {
+        var levelImage: String = ""
+
+        switch viewModel.state.loginStatusData.value?.basePosition ?? 1 {
+        case 1:
+            levelImage += "Dev_"
+        case 2:
+            levelImage += "Design_"
+        case 3:
+            levelImage += "Plan_"
+        default:
+            break
+        }
+        let level = viewModel.state.loginStatusData.value?.level ?? ""
+        switch level {
+        case _ where level.contains("씨앗"):
+            levelImage += "Lv1"
+        case _ where level.contains("열매"):
+            levelImage += "Lv2"
+        case _ where level.contains("꽃잎"):
+            levelImage += "Lv3"
+        case _ where level.contains("열매"):
+            levelImage += "Lv4"
+        default:
+            levelImage += "Lv4"
+        }
+
+        userLevelImageView.image = UIImage(named: levelImage)
     }
 
     private func configureLayout() {

--- a/Budi/Budi/Source/MyBudi/Level/MyBudiLevelViewController.swift
+++ b/Budi/Budi/Source/MyBudi/Level/MyBudiLevelViewController.swift
@@ -57,7 +57,7 @@ class MyBudiLevelViewController: UIViewController {
         switch level {
         case _ where level.contains("씨앗"):
             levelImage += "Lv1"
-        case _ where level.contains("열매"):
+        case _ where level.contains("새싹"):
             levelImage += "Lv2"
         case _ where level.contains("꽃잎"):
             levelImage += "Lv3"

--- a/Budi/Budi/Source/MyBudi/Main/Cells/MyBudiLevelCell.swift
+++ b/Budi/Budi/Source/MyBudi/Main/Cells/MyBudiLevelCell.swift
@@ -31,7 +31,33 @@ final class MyBudiLevelCell: UICollectionViewCell {
         
     }
 
-    func setLevel(level: String) {
+    func setLevel(level: String, position: Int) {
+        var levelImage: String = ""
+
+        switch position {
+        case 1:
+            levelImage += "Slider_Dev_"
+        case 2:
+            levelImage += "Slider_Design_"
+        case 3:
+            levelImage += "Slider_Plan_"
+        default:
+            break
+        }
+
+        switch level {
+        case _ where level.contains("씨앗"):
+            levelImage += "Lv1"
+        case _ where level.contains("열매"):
+            levelImage += "Lv2"
+        case _ where level.contains("꽃잎"):
+            levelImage += "Lv3"
+        case _ where level.contains("열매"):
+            levelImage += "Lv4"
+        default:
+            levelImage += "Lv4"
+        }
+
         switch level {
         case _ where level.contains("씨앗"):
             levelSlider.value = 0
@@ -44,6 +70,7 @@ final class MyBudiLevelCell: UICollectionViewCell {
         default:
             levelSlider.value = 1.0
         }
+        levelSlider.setThumbImage(UIImage(named: levelImage), for: .normal)
     }
 
     private func thumbImage() -> UIImage {

--- a/Budi/Budi/Source/MyBudi/Main/Cells/MyBudiLevelCell.swift
+++ b/Budi/Budi/Source/MyBudi/Main/Cells/MyBudiLevelCell.swift
@@ -48,7 +48,7 @@ final class MyBudiLevelCell: UICollectionViewCell {
         switch level {
         case _ where level.contains("씨앗"):
             levelImage += "Lv1"
-        case _ where level.contains("열매"):
+        case _ where level.contains("새싹"):
             levelImage += "Lv2"
         case _ where level.contains("꽃잎"):
             levelImage += "Lv3"

--- a/Budi/Budi/Source/MyBudi/Main/Cells/MyBudiProfileCell.swift
+++ b/Budi/Budi/Source/MyBudi/Main/Cells/MyBudiProfileCell.swift
@@ -8,14 +8,18 @@
 import UIKit
 import Combine
 import CombineCocoa
+import Kingfisher
 
 final class MyBudiProfileCell: UICollectionViewCell {
     var cancellables = Set<AnyCancellable>()
+
+    @IBOutlet weak var userCharacterImageView: UIImageView!
     @IBOutlet weak var editButton: UIButton!
     @IBOutlet weak var userNickNameLabel: UILabel!
     @IBOutlet weak var userPositionLabel: UILabel!
     @IBOutlet weak var userDescriptionLabel: UILabel!
-    
+    @IBOutlet weak var userImageView: UIImageView!
+
     override func prepareForReuse() {
         super.prepareForReuse()
         cancellables.removeAll()
@@ -29,6 +33,23 @@ final class MyBudiProfileCell: UICollectionViewCell {
         userNickNameLabel.text = nickName
         userPositionLabel.text = position
         userDescriptionLabel.text = description
+    }
+
+    func configureUserImage(url: String, basePosition: Int) {
+        guard let url = URL(string: url) else { return }
+        userImageView.contentMode = .scaleAspectFill
+        userImageView.kf.setImage(with: url)
+
+        switch basePosition {
+        case 1:
+            userCharacterImageView.image = UIImage(named: "Developer")
+        case 2:
+            userCharacterImageView.image = UIImage(named: "Designer")
+        case 3:
+            userCharacterImageView.image = UIImage(named: "Planner")
+        default:
+            break
+        }
     }
 
 }

--- a/Budi/Budi/Source/MyBudi/Main/Cells/MyBudiProfileCell.xib
+++ b/Budi/Budi/Source/MyBudi/Main/Cells/MyBudiProfileCell.xib
@@ -27,7 +27,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Developer_Background" translatesAutoresizingMaskIntoConstraints="NO" id="S75-HN-2ha">
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="S75-HN-2ha">
                                 <rect key="frame" x="136" y="20" width="72" height="72"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="72" id="fLh-B9-mdm"/>
@@ -75,11 +75,6 @@
                                     <constraint firstAttribute="width" constant="24" id="NdB-ef-5Y7"/>
                                     <constraint firstAttribute="height" constant="24" id="nYx-F8-XPV"/>
                                 </constraints>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                        <real key="value" value="36"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
                             </imageView>
                         </subviews>
                         <color key="backgroundColor" name="White"/>
@@ -114,7 +109,9 @@
             </constraints>
             <connections>
                 <outlet property="editButton" destination="Hid-N9-hde" id="y31-sf-K3K"/>
+                <outlet property="userCharacterImageView" destination="ngc-hF-sgq" id="KIe-a7-alr"/>
                 <outlet property="userDescriptionLabel" destination="eBb-sA-5I4" id="4Pc-vl-4IK"/>
+                <outlet property="userImageView" destination="S75-HN-2ha" id="8vo-VW-QaW"/>
                 <outlet property="userNickNameLabel" destination="nnc-NV-sUz" id="ylT-QK-Zoe"/>
                 <outlet property="userPositionLabel" destination="s0J-gq-0iG" id="2dp-ol-PBW"/>
             </connections>
@@ -122,8 +119,7 @@
         </collectionViewCell>
     </objects>
     <resources>
-        <image name="Developer" width="33" height="35"/>
-        <image name="Developer_Background" width="80" height="80"/>
+        <image name="Developer" width="40" height="40"/>
         <namedColor name="Primary">
             <color red="0.36899998784065247" green="0.37299999594688416" blue="0.85900002717971802" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/Budi/Budi/Source/MyBudi/Main/MyBudiMainViewController.swift
+++ b/Budi/Budi/Source/MyBudi/Main/MyBudiMainViewController.swift
@@ -145,7 +145,7 @@ extension MyBudiMainViewController: UICollectionViewDataSource, UICollectionView
             
         case 1: guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MyBudiLevelCell.identifier, for: indexPath) as? MyBudiLevelCell else { return defaultCell }
 
-            cell.setLevel(level: loginData?.level ?? "")
+            cell.setLevel(level: loginData?.level ?? "", position: self.viewModel.state.loginStatusData.value?.basePosition ?? 1)
 
             return cell
             

--- a/Budi/Budi/Source/MyBudi/Main/MyBudiMainViewController.swift
+++ b/Budi/Budi/Source/MyBudi/Main/MyBudiMainViewController.swift
@@ -137,7 +137,7 @@ extension MyBudiMainViewController: UICollectionViewDataSource, UICollectionView
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self] _ in
                     guard let self = self else { return }
-                    self.coordinator?.showEditViewController()
+                    self.coordinator?.showEditViewController(userData: self.viewModel.state.loginStatusData.value ?? nil)
                 }.store(in: &cell.cancellables)
             return cell
             

--- a/Budi/Budi/Source/MyBudi/Main/MyBudiMainViewController.swift
+++ b/Budi/Budi/Source/MyBudi/Main/MyBudiMainViewController.swift
@@ -91,7 +91,7 @@ final class MyBudiMainViewController: UIViewController {
             .store(in: &cancellables)
 
         loginButton.tapPublisher
-            .sink { [weak self] _ in
+            .sink { _ in
                 let storyboard = UIStoryboard(name: "Main", bundle: nil)
                 let loginSelectViewController = storyboard.instantiateViewController(identifier: "LoginSelectViewController")
                 let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
@@ -132,6 +132,8 @@ extension MyBudiMainViewController: UICollectionViewDataSource, UICollectionView
             } else {
                 cell.setUserData(nickName: loginData?.nickName ?? "로딩중", position: "임시글", description: loginData?.description ?? "임시소개글")
             }
+
+            cell.configureUserImage(url: viewModel.state.loginStatusData.value?.imgUrl ?? "", basePosition: viewModel.state.loginStatusData.value?.basePosition ?? 1)
 
             cell.editButton.tapPublisher
                 .receive(on: DispatchQueue.main)

--- a/Budi/Budi/Source/MyBudi/MyBudiCoordinator.swift
+++ b/Budi/Budi/Source/MyBudi/MyBudiCoordinator.swift
@@ -70,11 +70,10 @@ extension MyBudiCoordinator {
         vc.present(viewController, animated: false, completion: nil)
     }
 
-    func showProjectViewController(_ vc: UIViewController, viewModel: MyBudiEditViewModel) {
+    func showProjectViewController(_ vc: UIViewController, viewModel: SignupViewModel) {
         let sign = SignupViewModel()
-
         let viewController: HistoryWriteViewController = storyboard.instantiateViewController(identifier: HistoryWriteViewController.identifier) { coder -> HistoryWriteViewController? in
-            return HistoryWriteViewController(coder: coder, viewModel: SignupViewModel())
+            return HistoryWriteViewController(coder: coder, viewModel: viewModel)
         }
         viewController.delegate = vc as? HistoryWriteViewControllerDelegate
         viewController.myBudiCoordinator = self
@@ -83,10 +82,10 @@ extension MyBudiCoordinator {
         navigationController?.present(viewController, animated: true, completion: nil)
     }
 
-    func showPortfolioController(_ vc: UIViewController, viewModel: MyBudiEditViewModel) {
+    func showPortfolioController(_ vc: UIViewController, viewModel: SignupViewModel) {
         let signViewModel = SignupViewModel()
         let viewController: PortfolioViewController = storyboard.instantiateViewController(identifier: PortfolioViewController.identifier) { coder -> PortfolioViewController? in
-            return PortfolioViewController(coder: coder, viewModel: SignupViewModel())
+            return PortfolioViewController(coder: coder, viewModel: viewModel)
         }
         viewController.delegate = vc as? PortfolioViewControllerDelegate
         viewController.myBudiCoordinator = self

--- a/Budi/Budi/Source/MyBudi/MyBudiCoordinator.swift
+++ b/Budi/Budi/Source/MyBudi/MyBudiCoordinator.swift
@@ -26,8 +26,10 @@ final class MyBudiCoordinator: NavigationCoordinator {
 }
 
 extension MyBudiCoordinator {
-    func showEditViewController() {
-        let viewController: MyBudiEditViewController = MyBudiEditViewController(nibName: MyBudiEditViewController.identifier, bundle: nil, viewModel: MyBudiEditViewModel())
+    func showEditViewController(userData: LoginUserDetail?) {
+        let viewModel = MyBudiEditViewModel()
+        viewModel.state.loginUserData.value = userData
+        let viewController: MyBudiEditViewController = MyBudiEditViewController(nibName: MyBudiEditViewController.identifier, bundle: nil, viewModel: viewModel)
         viewController.coordinator = self
         navigationController?.pushViewController(viewController, animated: true)
     }
@@ -52,5 +54,44 @@ extension MyBudiCoordinator {
             }
         viewController.coordinator = self
         navigationController?.pushViewController(viewController, animated: true)
+    }
+
+    func showLocationSearchViewController(_ vc: UIViewController) {
+        let viewController = HomeLocationSearchViewController()
+        viewController.navigationItem.title = "위치선택"
+        viewController.delegate = vc as? HomeLocationSearchViewControllerDelegate
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+
+    func showProjectMembersBottomViewController(_ vc: UIViewController, _ viewModel: MyBudiEditViewModel) {
+        let viewController: ProjectMembersBottomViewController = ProjectMembersBottomViewController(nibName: ProjectMembersBottomViewController.identifier, bundle: nil, developerPositions: viewModel.state.developerPositions.value, designerPositions: viewModel.state.designerPositions.value, productManagerPositions: viewModel.state.productManagerPositions.value, viewSwitch: .myBudi)
+        viewController.delegate = vc as? ProjectMembersBottomViewControllerDelegate
+        viewController.modalPresentationStyle = .overCurrentContext
+        vc.present(viewController, animated: false, completion: nil)
+    }
+
+    func showProjectViewController(_ vc: UIViewController, viewModel: MyBudiEditViewModel) {
+        let sign = SignupViewModel()
+
+        let viewController: HistoryWriteViewController = storyboard.instantiateViewController(identifier: HistoryWriteViewController.identifier) { coder -> HistoryWriteViewController? in
+            return HistoryWriteViewController(coder: coder, viewModel: SignupViewModel())
+        }
+        viewController.delegate = vc as? HistoryWriteViewControllerDelegate
+        viewController.myBudiCoordinator = self
+        viewController.viewModel.action.switchView.send(ModalControl.project)
+        viewController.modalPresentationStyle = .overFullScreen
+        navigationController?.present(viewController, animated: true, completion: nil)
+    }
+
+    func showPortfolioController(_ vc: UIViewController, viewModel: MyBudiEditViewModel) {
+        let signViewModel = SignupViewModel()
+        let viewController: PortfolioViewController = storyboard.instantiateViewController(identifier: PortfolioViewController.identifier) { coder -> PortfolioViewController? in
+            return PortfolioViewController(coder: coder, viewModel: SignupViewModel())
+        }
+        viewController.delegate = vc as? PortfolioViewControllerDelegate
+        viewController.myBudiCoordinator = self
+        viewController.modalPresentationStyle = .overFullScreen
+        viewController.viewModel.action.switchView.send(ModalControl.portfolio)
+        navigationController?.present(viewController, animated: true, completion: nil)
     }
 }

--- a/Budi/Budi/Source/ReuseViews/PortfolioURLTableViewCell.swift
+++ b/Budi/Budi/Source/ReuseViews/PortfolioURLTableViewCell.swift
@@ -33,22 +33,22 @@ class PortfolioURLTableViewCell: UITableViewCell {
 
     }
 
-    func configureParsing(url: String) {
+    func configureParsing(urlString: String) {
         portfolioView.isHidden = false
-        let sep = url.split(separator: "/")
-        if sep[0] == "https:" {
-            switch sep[1] {
-            case "www.behance.net":
-                portfolioUrlFaviconImageView.image = UIImage(named: "Behance")
-            case "www.linkedin.com":
-                portfolioUrlFaviconImageView.image = UIImage(named: "Linkedin")
-            case "www.instagram.com":
-                portfolioUrlFaviconImageView.image = UIImage(named: "Instagram")
-            default:
-                portfolioUrlFaviconImageView.image = UIImage(named: "Others")
-            }
+        portfolioUrlLabel.text = urlString
+        guard let url = URL(string: urlString) else { return }
+        
+        switch url.host {
+        case "www.behance.net":
+            portfolioUrlFaviconImageView.image = UIImage(named: "Behance")
+        case "www.linkedin.com":
+            portfolioUrlFaviconImageView.image = UIImage(named: "Linkedin")
+        case "www.instagram.com":
+            portfolioUrlFaviconImageView.image = UIImage(named: "Instagram")
+        default:
+            portfolioUrlFaviconImageView.image = UIImage(named: "Others")
         }
-        portfolioUrlLabel.text = url
+
     }
 
     func configureButtonLabel(text: String) {

--- a/Budi/Budi/Source/ReuseViews/PortfolioURLTableViewCell.swift
+++ b/Budi/Budi/Source/ReuseViews/PortfolioURLTableViewCell.swift
@@ -11,17 +11,21 @@ class PortfolioURLTableViewCell: UITableViewCell {
 
     static let cellId = "PortfolioURLTableViewCell"
     var cancellables = Set<AnyCancellable>()
+    @IBOutlet weak var portfolioView: UIView!
     @IBOutlet weak var portfolioUrlFaviconImageView: UIImageView!
     @IBOutlet weak var portfolioUrlLabel: UILabel!
     @IBOutlet weak var editButton: UIButton!
-
+    @IBOutlet weak var addButton: UIButton!
     override func prepareForReuse() {
         super.prepareForReuse()
         cancellables.removeAll()
+        portfolioView.isHidden = true
     }
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        portfolioView.isHidden = true
+        self.selectionStyle = .none
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {
@@ -30,6 +34,7 @@ class PortfolioURLTableViewCell: UITableViewCell {
     }
 
     func configureParsing(url: String) {
+        portfolioView.isHidden = false
         let sep = url.split(separator: "/")
         if sep[0] == "https:" {
             switch sep[1] {
@@ -45,5 +50,8 @@ class PortfolioURLTableViewCell: UITableViewCell {
         }
         portfolioUrlLabel.text = url
     }
-    
+
+    func configureButtonLabel(text: String) {
+        addButton.setTitle(text, for: .normal)
+    }
 }

--- a/Budi/Budi/Source/ReuseViews/PortfolioURLTableViewCell.xib
+++ b/Budi/Budi/Source/ReuseViews/PortfolioURLTableViewCell.xib
@@ -35,7 +35,7 @@
                         <rect key="frame" x="8" y="8" width="327" height="42"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ppZ-FT-cUB">
-                                <rect key="frame" x="16" y="5" width="28" height="28"/>
+                                <rect key="frame" x="16" y="8" width="28" height="28"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="28" id="Tcu-eT-WGf"/>
                                     <constraint firstAttribute="width" constant="28" id="V5T-kA-YK8"/>
@@ -60,7 +60,7 @@
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="ppZ-FT-cUB" firstAttribute="top" secondItem="wuH-dm-qys" secondAttribute="top" constant="5" id="0IM-4q-ZOg"/>
+                            <constraint firstItem="ppZ-FT-cUB" firstAttribute="top" secondItem="wuH-dm-qys" secondAttribute="top" constant="8" id="0IM-4q-ZOg"/>
                             <constraint firstItem="Pio-mV-HSC" firstAttribute="leading" secondItem="ppZ-FT-cUB" secondAttribute="trailing" constant="8" symbolic="YES" id="0wI-re-sCa"/>
                             <constraint firstAttribute="trailing" secondItem="9Lk-RE-qft" secondAttribute="trailing" constant="22" id="13b-9c-bWa"/>
                             <constraint firstItem="9Lk-RE-qft" firstAttribute="top" secondItem="wuH-dm-qys" secondAttribute="top" constant="8" id="FiD-3U-rYX"/>

--- a/Budi/Budi/Source/ReuseViews/PortfolioURLTableViewCell.xib
+++ b/Budi/Budi/Source/ReuseViews/PortfolioURLTableViewCell.xib
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -12,14 +13,26 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <tableViewCell contentMode="scaleToFill" restorationIdentifier="PortfolioURLTableViewCell" selectionStyle="default" indentationWidth="10" reuseIdentifier="PortfolioURLTableViewCell" id="KGk-i7-Jjw" customClass="PortfolioURLTableViewCell" customModule="Budi" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="343" height="48"/>
+            <rect key="frame" x="0.0" y="0.0" width="343" height="55"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="343" height="48"/>
+                <rect key="frame" x="0.0" y="0.0" width="343" height="55"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
+                    <button opaque="NO" alpha="0.87000000476837158" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8Zc-Go-pc7">
+                        <rect key="frame" x="8" y="8" width="327" height="38"/>
+                        <color key="backgroundColor" name="Primary_sub"/>
+                        <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="0.87" colorSpace="custom" customColorSpace="displayP3"/>
+                        <state key="normal" title="Button"/>
+                        <buttonConfiguration key="configuration" style="plain" image="locationAddButton" title="경력을 추가해보세요"/>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                <real key="value" value="8"/>
+                            </userDefinedRuntimeAttribute>
+                        </userDefinedRuntimeAttributes>
+                    </button>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wuH-dm-qys">
-                        <rect key="frame" x="8" y="5" width="327" height="38"/>
+                        <rect key="frame" x="8" y="8" width="327" height="42"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ppZ-FT-cUB">
                                 <rect key="frame" x="16" y="5" width="28" height="28"/>
@@ -50,11 +63,10 @@
                             <constraint firstItem="ppZ-FT-cUB" firstAttribute="top" secondItem="wuH-dm-qys" secondAttribute="top" constant="5" id="0IM-4q-ZOg"/>
                             <constraint firstItem="Pio-mV-HSC" firstAttribute="leading" secondItem="ppZ-FT-cUB" secondAttribute="trailing" constant="8" symbolic="YES" id="0wI-re-sCa"/>
                             <constraint firstAttribute="trailing" secondItem="9Lk-RE-qft" secondAttribute="trailing" constant="22" id="13b-9c-bWa"/>
-                            <constraint firstAttribute="height" constant="38" id="BBN-kM-WIz"/>
                             <constraint firstItem="9Lk-RE-qft" firstAttribute="top" secondItem="wuH-dm-qys" secondAttribute="top" constant="8" id="FiD-3U-rYX"/>
-                            <constraint firstAttribute="width" constant="327" id="K7Y-Yg-jV2"/>
                             <constraint firstAttribute="trailing" secondItem="Pio-mV-HSC" secondAttribute="trailing" constant="8" id="LSZ-ga-7bI"/>
                             <constraint firstItem="ppZ-FT-cUB" firstAttribute="leading" secondItem="wuH-dm-qys" secondAttribute="leading" constant="16" id="PIy-H8-PEm"/>
+                            <constraint firstAttribute="height" constant="42" id="Yl3-jG-Lpz"/>
                             <constraint firstItem="Pio-mV-HSC" firstAttribute="top" secondItem="wuH-dm-qys" secondAttribute="top" constant="10" id="yBr-v5-uOB"/>
                         </constraints>
                         <userDefinedRuntimeAttributes>
@@ -74,20 +86,30 @@
                     <constraint firstItem="wuH-dm-qys" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="8" id="1QL-WB-JeK"/>
                     <constraint firstAttribute="bottom" secondItem="wuH-dm-qys" secondAttribute="bottom" constant="5" id="8Bf-th-tff"/>
                     <constraint firstAttribute="trailing" secondItem="wuH-dm-qys" secondAttribute="trailing" constant="8" id="8Kt-1m-4ML"/>
-                    <constraint firstItem="wuH-dm-qys" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="5" id="Fbf-Ju-fUI"/>
+                    <constraint firstItem="8Zc-Go-pc7" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="9ap-IZ-DeP"/>
+                    <constraint firstAttribute="bottom" secondItem="8Zc-Go-pc7" secondAttribute="bottom" constant="9" id="F4G-px-c2L"/>
+                    <constraint firstItem="wuH-dm-qys" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="Skb-Yw-W98"/>
+                    <constraint firstAttribute="trailing" secondItem="8Zc-Go-pc7" secondAttribute="trailing" constant="8" id="Uhi-XQ-tHV"/>
+                    <constraint firstItem="8Zc-Go-pc7" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="8" id="rKb-Jn-M7i"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="addButton" destination="8Zc-Go-pc7" id="OG7-27-eQg"/>
                 <outlet property="editButton" destination="9Lk-RE-qft" id="H6J-vh-gRD"/>
                 <outlet property="portfolioUrlFaviconImageView" destination="ppZ-FT-cUB" id="Kt9-il-yzq"/>
                 <outlet property="portfolioUrlLabel" destination="Pio-mV-HSC" id="GqF-nr-XQm"/>
+                <outlet property="portfolioView" destination="wuH-dm-qys" id="nyC-dB-jLR"/>
             </connections>
-            <point key="canvasLocation" x="136.95652173913044" y="59.598214285714285"/>
+            <point key="canvasLocation" x="136.95652173913044" y="59.263392857142854"/>
         </tableViewCell>
     </objects>
     <resources>
         <image name="ellipsis" catalog="system" width="128" height="37"/>
+        <image name="locationAddButton" width="24" height="24"/>
+        <namedColor name="Primary_sub">
+            <color red="0.92549019607843142" green="0.92941176470588238" blue="0.98039215686274506" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Budi/Budi/Source/Storyborads/Base.lproj/Main.storyboard
+++ b/Budi/Budi/Source/Storyborads/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>


### PR DESCRIPTION
### 개요

- #61 

### 작업사항
![무제 3 001](https://user-images.githubusercontent.com/11778058/149292867-f7e9c9ac-a743-4d8d-bf37-eca7b5190c76.png)

왼쪽부터
1. 로그인 뷰에서 레벨 표시 슬라이더의 이미지 레벨에 따라 변경 구현
2. 프로필 수정 뷰 구현, 모든 버튼과 텍스트 필드 수정 가능, 그리고 저장 버튼을 눌러야지만 서버에 전송됨
3. 프로젝트 이력과, 포트폴리오도 추가, 수정이 가능 이 역시 전송버튼을 눌러야 서버에 전송
4. 레벨 페이지도 레벨에 따라 이미지 변경 구현

### 특이사항

- 없음